### PR TITLE
P4: shared cuboid geometry helpers (fold/tab rendering)

### DIFF
--- a/src/builder/modules/generator.fake.ts
+++ b/src/builder/modules/generator.fake.ts
@@ -1,0 +1,14 @@
+import { Generator } from "./generator";
+import { Model } from "./model";
+import { Values } from "./modelValues";
+
+/**
+ * A real `Generator` instance backed by an empty `Model`/`Values`, for use in
+ * tests. Both constructors are trivial and side-effect-free, so this needs no
+ * hand-written stub of `Generator`'s public methods and no type assertion.
+ *
+ * Spy on whichever methods a test needs with `vi.spyOn(generator, "method")`.
+ */
+export function makeFakeGenerator(): Generator {
+  return new Generator(new Model(new Values()));
+}

--- a/src/generators/_common/clearVariablesMatching.ts
+++ b/src/generators/_common/clearVariablesMatching.ts
@@ -1,0 +1,12 @@
+import { type Generator } from "@genroot/builder/modules/generator";
+
+export function clearVariablesMatching(
+  generator: Generator,
+  idPattern: RegExp
+): void {
+  Array.from(generator.model.values.variables.keys()).forEach((id) => {
+    if (idPattern.test(id)) {
+      generator.model.values.variables.delete(id);
+    }
+  });
+}

--- a/src/generators/_common/cuboidFolds.test.ts
+++ b/src/generators/_common/cuboidFolds.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { type Generator } from "@genroot/builder/modules/generator";
+import { drawCuboidFolds, drawRectangleFolds } from "./cuboidFolds";
+
+function makeGenerator(): Generator {
+  return {
+    drawFoldLine: vi.fn(),
+  } as unknown as Generator;
+}
+
+describe("cuboidFolds", () => {
+  it("draws rectangle folds around the rectangle edges", () => {
+    const generator = makeGenerator();
+
+    drawRectangleFolds(generator, [10, 20, 30, 40]);
+
+    expect(generator.drawFoldLine).toHaveBeenCalledTimes(4);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(1, [10, 19], [40, 19]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(2, [40, 20], [40, 60]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(3, [39, 60], [10, 60]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(4, [9, 59], [9, 20]);
+  });
+
+  it("draws the west-facing cuboid fold layout by default", () => {
+    const generator = makeGenerator();
+
+    drawCuboidFolds(generator, [10, 20], [30, 40, 50]);
+
+    expect(generator.drawFoldLine).toHaveBeenCalledTimes(9);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(1, [60, 19], [90, 19]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      5,
+      [10, 69],
+      [170, 69]
+    );
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      9,
+      [139, 70],
+      [139, 110]
+    );
+  });
+
+  it("draws the east-facing cuboid fold layout", () => {
+    const generator = makeGenerator();
+
+    drawCuboidFolds(generator, [10, 20], [30, 40, 50], {
+      orientation: "East",
+    });
+
+    expect(generator.drawFoldLine).toHaveBeenCalledTimes(9);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(1, [90, 19], [120, 19]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(9, [40, 70], [40, 110]);
+  });
+
+  it("draws the north-facing cuboid fold layout", () => {
+    const generator = makeGenerator();
+
+    drawCuboidFolds(generator, [10, 20], [30, 40, 50], {
+      orientation: "North",
+    });
+
+    expect(generator.drawFoldLine).toHaveBeenCalledTimes(9);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(1, [60, 19], [90, 19]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      5,
+      [10, 69],
+      [140, 69]
+    );
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      9,
+      [60, 159],
+      [90, 159]
+    );
+  });
+
+  it("draws the south-facing cuboid fold layout", () => {
+    const generator = makeGenerator();
+
+    drawCuboidFolds(generator, [10, 20], [30, 40, 50], {
+      orientation: "South",
+    });
+
+    expect(generator.drawFoldLine).toHaveBeenCalledTimes(9);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(1, [60, 19], [90, 19]);
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      5,
+      [10, 109],
+      [140, 109]
+    );
+    expect(generator.drawFoldLine).toHaveBeenNthCalledWith(
+      9,
+      [60, 60],
+      [90, 60]
+    );
+  });
+});

--- a/src/generators/_common/cuboidFolds.test.ts
+++ b/src/generators/_common/cuboidFolds.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { type Generator } from "@genroot/builder/modules/generator";
+import { makeFakeGenerator } from "@genroot/builder/modules/generator.fake";
 import { drawCuboidFolds, drawRectangleFolds } from "./cuboidFolds";
 
 function makeGenerator(): Generator {
-  return {
-    drawFoldLine: vi.fn(),
-  } as unknown as Generator;
+  const generator = makeFakeGenerator();
+  vi.spyOn(generator, "drawFoldLine").mockImplementation(() => {});
+  return generator;
 }
 
 describe("cuboidFolds", () => {

--- a/src/generators/_common/cuboidFolds.ts
+++ b/src/generators/_common/cuboidFolds.ts
@@ -1,0 +1,60 @@
+import { type Generator } from "@genroot/builder/modules/generator";
+import { type Dimensions, type Position, type Rectangle } from "./cuboid";
+import { type Orientation } from "./minecraft";
+
+export type CuboidFoldOptions = {
+  orientation?: Orientation;
+};
+
+export function drawRectangleFolds(generator: Generator, rectangle: Rectangle) {
+  const [x, y, w, h] = rectangle;
+
+  generator.drawFoldLine([x, y - 1], [x + w, y - 1]);
+  generator.drawFoldLine([x + w, y], [x + w, y + h]);
+  generator.drawFoldLine([x + w - 1, y + h], [x, y + h]);
+  generator.drawFoldLine([x - 1, y + h - 1], [x - 1, y]);
+}
+
+export function drawCuboidFolds(
+  generator: Generator,
+  position: Position,
+  dimensions: Dimensions,
+  options: CuboidFoldOptions = {}
+) {
+  const [x, y] = position;
+  const [w, h, d] = dimensions;
+  const orientation = options.orientation ?? "West";
+
+  switch (orientation) {
+    case "East": {
+      drawRectangleFolds(generator, [x + w + d, y, w, d * 2 + h]);
+      drawRectangleFolds(generator, [x, y + d, d * 2 + w * 2, h]);
+      generator.drawFoldLine([x + w, y + d], [x + w, y + d + h]);
+      break;
+    }
+    case "North": {
+      drawRectangleFolds(generator, [x + d, y, w, d * 2 + h * 2]);
+      drawRectangleFolds(generator, [x, y + d, d * 2 + w, h]);
+      generator.drawFoldLine(
+        [x + d, y + d * 2 + h - 1],
+        [x + d + w, y + d * 2 + h - 1]
+      );
+      break;
+    }
+    case "South": {
+      drawRectangleFolds(generator, [x + d, y, w, d * 2 + h * 2]);
+      drawRectangleFolds(generator, [x, y + d + h, d * 2 + w, h]);
+      generator.drawFoldLine([x + d, y + h], [x + d + w, y + h]);
+      break;
+    }
+    case "West": {
+      drawRectangleFolds(generator, [x + d, y, w, d * 2 + h]);
+      drawRectangleFolds(generator, [x, y + d, d * 2 + w * 2, h]);
+      generator.drawFoldLine(
+        [x + d * 2 + w - 1, y + d],
+        [x + d * 2 + w - 1, y + d + h]
+      );
+      break;
+    }
+  }
+}

--- a/src/generators/_common/cuboidTabs.test.ts
+++ b/src/generators/_common/cuboidTabs.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { type Generator } from "@genroot/builder/modules/generator";
+import { drawCuboidTabs, getDioramaEdgeTabThickness } from "./cuboidTabs";
+
+function makeGenerator(): Generator {
+  return {
+    drawTab: vi.fn(),
+  } as unknown as Generator;
+}
+
+describe("cuboidTabs", () => {
+  it("uses the diorama edge tab thickness rule", () => {
+    expect(getDioramaEdgeTabThickness(168, 168)).toBe(32);
+    expect(getDioramaEdgeTabThickness(128, 16)).toBe(8);
+  });
+
+  it("draws default tabs on the right, left, and back faces", () => {
+    const generator = makeGenerator();
+
+    drawCuboidTabs(generator, [10, 20], [30, 40, 50]);
+
+    expect(generator.drawTab).toHaveBeenCalledTimes(7);
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      1,
+      [10, 57.5, 50, 12.5],
+      "North",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      2,
+      [10, 110, 50, 12.5],
+      "South",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      3,
+      [-2.5, 70, 12.5, 40],
+      "West",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      6,
+      [140, 57.5, 30, 12.5],
+      "North",
+      false,
+      45
+    );
+  });
+
+  it("keeps small cuboid tabs proportional to their face", () => {
+    const generator = makeGenerator();
+
+    drawCuboidTabs(generator, [10, 20], [4, 8, 4]);
+
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      1,
+      [10, 23, 4, 1],
+      "North",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      3,
+      [9, 24, 1, 8],
+      "West",
+      false,
+      45
+    );
+  });
+
+  it("matches diorama tab thickness when a larger base size is provided", () => {
+    const generator = makeGenerator();
+
+    drawCuboidTabs(generator, [10, 20], [30, 40, 50], {
+      baseDimensions: [128, 128, 128],
+    });
+
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      1,
+      [10, 45, 50, 25],
+      "North",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      3,
+      [-15, 70, 25, 40],
+      "West",
+      false,
+      45
+    );
+    expect(generator.drawTab).toHaveBeenNthCalledWith(
+      6,
+      [140, 45, 30, 25],
+      "North",
+      false,
+      45
+    );
+  });
+
+  it("supports custom placements and tab options", () => {
+    const generator = makeGenerator();
+
+    drawCuboidTabs(generator, [10, 20], [30, 40, 50], {
+      placements: [{ face: "back", edge: "Right" }],
+      showFoldLine: true,
+      tabAngle: 60,
+    });
+
+    expect(generator.drawTab).toHaveBeenCalledTimes(1);
+    expect(generator.drawTab).toHaveBeenCalledWith(
+      [170, 70, 7.5, 40],
+      "East",
+      true,
+      60
+    );
+  });
+});

--- a/src/generators/_common/cuboidTabs.test.ts
+++ b/src/generators/_common/cuboidTabs.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { type Generator } from "@genroot/builder/modules/generator";
+import { makeFakeGenerator } from "@genroot/builder/modules/generator.fake";
 import { drawCuboidTabs, getDioramaEdgeTabThickness } from "./cuboidTabs";
 
 function makeGenerator(): Generator {
-  return {
-    drawTab: vi.fn(),
-  } as unknown as Generator;
+  const generator = makeFakeGenerator();
+  vi.spyOn(generator, "drawTab").mockImplementation(() => {});
+  return generator;
 }
 
 describe("cuboidTabs", () => {

--- a/src/generators/_common/cuboidTabs.ts
+++ b/src/generators/_common/cuboidTabs.ts
@@ -1,0 +1,139 @@
+import {
+  type Generator,
+  type Region,
+} from "@genroot/builder/modules/generator";
+import { type TabOrientation } from "@genroot/builder/modules/renderers/drawTab";
+import { type Dimensions, type Position, type Rectangle } from "./cuboid";
+
+const maxEdgeRegionThickness = (16 * 800) / 100 / 4;
+
+export type CuboidTabFace = "right" | "left" | "back";
+export type CuboidTabEdge = "Top" | "Bottom" | "Left" | "Right";
+
+export type CuboidTabPlacement = {
+  face: CuboidTabFace;
+  edge: CuboidTabEdge;
+};
+
+export type CuboidTabOptions = {
+  baseDimensions?: Dimensions;
+  placements?: CuboidTabPlacement[];
+  showFoldLine?: boolean;
+  tabAngle?: number;
+};
+
+const defaultPlacements: CuboidTabPlacement[] = [
+  { face: "right", edge: "Top" },
+  { face: "right", edge: "Bottom" },
+  { face: "right", edge: "Left" },
+  { face: "left", edge: "Top" },
+  { face: "left", edge: "Bottom" },
+  { face: "back", edge: "Top" },
+  { face: "back", edge: "Bottom" },
+];
+
+export function getDioramaEdgeTabThickness(
+  baseSize: number,
+  faceSize: number
+): number {
+  return Math.min(baseSize / 4, maxEdgeRegionThickness, faceSize / 2);
+}
+
+function makeWestCuboidFaces(
+  [x, y]: Position,
+  [w, h, d]: Dimensions,
+  [baseW, , baseD]: Dimensions
+): Record<
+  CuboidTabFace,
+  {
+    baseHeight: number;
+    baseWidth: number;
+    rectangle: Rectangle;
+  }
+> {
+  return {
+    right: {
+      baseWidth: baseD,
+      baseHeight: baseD,
+      rectangle: [x, y + d, d, h],
+    },
+    left: {
+      baseWidth: baseD,
+      baseHeight: baseD,
+      rectangle: [x + d + w, y + d, d, h],
+    },
+    back: {
+      baseWidth: baseW,
+      baseHeight: baseD,
+      rectangle: [x + d * 2 + w, y + d, w, h],
+    },
+  };
+}
+
+function makeTabRegion(
+  [x, y, width, height]: Rectangle,
+  edge: CuboidTabEdge,
+  baseWidth: number,
+  baseHeight: number,
+  horizontalFaceSize: number
+): { region: Region; orientation: TabOrientation } {
+  const horizontalThickness = getDioramaEdgeTabThickness(
+    baseHeight,
+    horizontalFaceSize
+  );
+  const verticalThickness = getDioramaEdgeTabThickness(baseWidth, width);
+
+  switch (edge) {
+    case "Top":
+      return {
+        region: [x, y - horizontalThickness, width, horizontalThickness],
+        orientation: "North",
+      };
+    case "Bottom":
+      return {
+        region: [x, y + height, width, horizontalThickness],
+        orientation: "South",
+      };
+    case "Left":
+      return {
+        region: [x - verticalThickness, y, verticalThickness, height],
+        orientation: "West",
+      };
+    case "Right":
+      return {
+        region: [x + width, y, verticalThickness, height],
+        orientation: "East",
+      };
+  }
+}
+
+export function drawCuboidTabs(
+  generator: Generator,
+  position: Position,
+  dimensions: Dimensions,
+  options: CuboidTabOptions = {}
+) {
+  const faces = makeWestCuboidFaces(
+    position,
+    dimensions,
+    options.baseDimensions ?? dimensions
+  );
+  const placements = options.placements ?? defaultPlacements;
+
+  placements.forEach(({ face, edge }) => {
+    const { baseHeight, baseWidth, rectangle } = faces[face];
+    const { region, orientation } = makeTabRegion(
+      rectangle,
+      edge,
+      baseWidth,
+      baseHeight,
+      dimensions[2]
+    );
+    generator.drawTab(
+      region,
+      orientation,
+      options.showFoldLine ?? false,
+      options.tabAngle ?? 45
+    );
+  });
+}

--- a/src/generators/_common/minecraftEntity.ts
+++ b/src/generators/_common/minecraftEntity.ts
@@ -69,3 +69,25 @@ export const horse: Horse = {
   leg: translate(cuboid([4, 11, 4]), [48, 21]),
   chest: translate(cuboid([8, 8, 3]), [26, 21]),
 };
+
+export type Banner = {
+  flag: Cuboid;
+  pole: Cuboid;
+  bar: Cuboid;
+};
+
+export const banner: Banner = {
+  flag: translate(cuboid([20, 40, 1]), [0, 0]),
+  pole: translate(cuboid([2, 42, 2]), [44, 0]),
+  bar: translate(cuboid([20, 2, 2]), [0, 42]),
+};
+
+export type Shield = {
+  shield: Cuboid;
+  handle: Cuboid;
+};
+
+export const shield: Shield = {
+  shield: translate(cuboid([12, 22, 1]), [0, 0]),
+  handle: translate(cuboid([2, 6, 6]), [26, 0]),
+};


### PR DESCRIPTION
## Summary
- Part of the [incremental PR-35 rebuild plan](https://github.com/pixelpapercraft/pixel-papercraft-generators) — P4 of the sequence, sliced from `pr-35-rebuild` commit `b3ecfbb`.
- Adds net-new shared cuboid geometry helpers with **zero existing consumers** — nothing else in the codebase imports these yet, so there's no behavior change to anything currently on `main`:
  - `_common/clearVariablesMatching.ts` — removes model variables matching a regex pattern
  - `_common/cuboidFolds.ts` — `drawRectangleFolds`/`drawCuboidFolds`, fold-line layout for a cuboid net in each of the 4 orientations
  - `_common/cuboidTabs.ts` — `drawCuboidTabs`/`getDioramaEdgeTabThickness`, tab placement/sizing for a cuboid net
  - Additive `Banner`/`Shield` cuboid data in `_common/minecraftEntity.ts` (consumed later by P12, the Banner and Shield generator itself)
- Ported **without** upstream's `lightColor`/`tabType` renderer options, which depend on unrelated rewrites of `drawLine.ts`/`drawTab.ts` that nothing in the actual feature ever exercises (confirmed via full-codebase grep on the source branch) — both files call `main`'s existing, unmodified `drawFoldLine`/`drawTab` signatures instead.
- **Retrofitted the tests to comply with the new TypeScript rules** (landed on `main` after this PR was first opened): the original test mocks used `as unknown as Generator`, since banned by `agent-docs/rules/typescript.md`. Rather than casting, added `src/builder/modules/generator.fake.ts` — a reusable `makeFakeGenerator()` that returns a **real** `Generator` instance (its constructor chain, `Model`/`Values`, is trivial and side-effect-free), so tests `vi.spyOn()` just the method(s) they assert on instead of hand-faking or casting. This helper is intended for reuse by the other test files that still have the old cast pattern (`glint.test.ts`, `face.test.ts`, `shelf.test.ts`, `drawTexture.test.ts`) in a follow-up PR.

## Test plan
- [x] `cuboidFolds.test.ts` (5 tests) + `cuboidTabs.test.ts` (5 tests) — pure TDD, define the fold/tab layout behavior
- [x] Full `npm run test:unit` green (114/114)
- [x] `npm run types:check` clean
- [x] `npm run lint` clean
- No Playwright suite needed — this slice has no consumers yet, so nothing renderable changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)