### PR TITLE
Add exhaustive drawTexture rotate/flip combination matrix

### DIFF
--- a/src/generators/testApiDrawingTextures/testApiDrawingTexturesGenerator.ts
+++ b/src/generators/testApiDrawingTextures/testApiDrawingTexturesGenerator.ts
@@ -27,6 +27,10 @@ distinct 2x2 quadrant colours (red top-left, green top-right, blue
 bottom-left, yellow bottom-right), so rotate/flip and every blend mode are
 verifiable by which exact colours land where. See the generator-api
 test-coverage plan.
+
+The final page is an exhaustive 7x3 rotate/flip combination matrix (every
+Center/Corner rotation x every flip); see the rotate/flip combination matrix
+spec.
 `;
 
 // The same 4x4 fixture is used both as a raw image (drawImage) and as a
@@ -135,6 +139,57 @@ const script: ScriptDef = (generator: Generator) => {
       hex1: ["#00ff00", "#ffff00"],
       hex2: ["#abcdef", "#102030"],
     },
+  });
+
+  // --- Page 12: rotate/flip combination matrix -----------------------------
+  // Exhaustive 7x3 grid of every drawTexture rotate x flip combination (see the
+  // rotate/flip combination matrix spec). Rows = rotate state (None, Center
+  // 90/180/270, Corner 90/180/270); cols = flip (None, Horizontal, Vertical).
+  // Square cells of side S. Corner rotations pivot about the dest origin, so
+  // their origin is shifted to the cell corner that brings the rotated square
+  // back into its cell. The spec re-derives these same cell positions and the
+  // expected quadrant colours (rotate-of-flip); keep the two in lock-step.
+  generator.usePage("TextureTransformMatrix");
+  const S = 40;
+  const GAP = 20;
+  const ORIGIN_X = 40;
+  const ORIGIN_Y = 40;
+  const matrixRotations: {
+    options: { rotate?: number; rotateLegacy?: number };
+    cornerDegrees: number;
+  }[] = [
+    { options: {}, cornerDegrees: 0 }, // None
+    { options: { rotate: 90 }, cornerDegrees: 0 }, // Center 90
+    { options: { rotate: 180 }, cornerDegrees: 0 }, // Center 180
+    { options: { rotate: 270 }, cornerDegrees: 0 }, // Center 270
+    { options: { rotateLegacy: 90 }, cornerDegrees: 90 }, // Corner 90
+    { options: { rotateLegacy: 180 }, cornerDegrees: 180 }, // Corner 180
+    { options: { rotateLegacy: 270 }, cornerDegrees: 270 }, // Corner 270
+  ];
+  const matrixFlips: ("Horizontal" | "Vertical" | undefined)[] = [
+    undefined,
+    "Horizontal",
+    "Vertical",
+  ];
+  matrixRotations.forEach((rotation, row) => {
+    matrixFlips.forEach((flip, col) => {
+      const cx = ORIGIN_X + col * (S + GAP);
+      const cy = ORIGIN_Y + row * (S + GAP);
+      let dx = cx;
+      let dy = cy;
+      if (rotation.cornerDegrees === 90) {
+        dx = cx + S;
+      } else if (rotation.cornerDegrees === 180) {
+        dx = cx + S;
+        dy = cy + S;
+      } else if (rotation.cornerDegrees === 270) {
+        dy = cy + S;
+      }
+      generator.drawTexture("Quadrants", [0, 0, 4, 4], [dx, dy, S, S], {
+        ...rotation.options,
+        ...(flip ? { flip } : {}),
+      });
+    });
   });
 };
 

--- a/tests/generators/testApiDrawingTexturesGenerator/testApiDrawingTexturesGenerator.spec.ts
+++ b/tests/generators/testApiDrawingTexturesGenerator/testApiDrawingTexturesGenerator.spec.ts
@@ -17,6 +17,7 @@ import { readPixel, type Rgba } from "../_shared/pixelColor";
 //   9 TextureMultiplyColor — drawTexture (33) MultiplyColor blend
 //  10 TextureReplaceColor  — drawTexture (33) ReplaceColor blend
 //  11 TextureReplaceHex    — drawTexture (33) ReplaceHex blend
+//  12 TextureTransformMatrix — drawTexture (33) exhaustive rotate x flip matrix
 // See the generator-api test-coverage plan.
 
 const red: Rgba = { r: 255, g: 0, b: 0, a: 255 };
@@ -246,4 +247,113 @@ test("drawTexture ReplaceHex replaces exact hex-palette matches and preserves ot
   expect(q.tr).toEqual(replacementGreen);
   expect(q.bl).toEqual(blue);
   expect(q.br).toEqual(replacementYellow);
+});
+
+// --- rotate/flip combination matrix (page 12) -------------------------------
+// Exhaustive verification of every drawTexture rotate x flip combination. The
+// generator draws a 7x3 grid on page 12 (rows = rotate state, cols = flip); this
+// re-derives the same cell positions and asserts the expected quadrant colours.
+// The rotation/flip order and the layout constants must stay in lock-step with
+// testApiDrawingTexturesGenerator.ts. See the rotate/flip combination matrix spec.
+
+type Quad = { tl: Rgba; tr: Rgba; bl: Rgba; br: Rgba };
+
+const matrixBase: Quad = { tl: red, tr: green, bl: blue, br: yellow };
+
+function applyFlip(
+  q: Quad,
+  flip: "Horizontal" | "Vertical" | undefined
+): Quad {
+  if (flip === "Horizontal") return { tl: q.tr, tr: q.tl, bl: q.br, br: q.bl };
+  if (flip === "Vertical") return { tl: q.bl, tr: q.br, bl: q.tl, br: q.tr };
+  return q;
+}
+
+// Clockwise, matching the canvas rotate direction (verified against the
+// standalone rotate 90/180 tests above).
+function applyRotate(q: Quad, degrees: number): Quad {
+  switch (degrees) {
+    case 90:
+      return { tl: q.bl, tr: q.tl, br: q.tr, bl: q.br };
+    case 180:
+      return { tl: q.br, tr: q.bl, bl: q.tr, br: q.tl };
+    case 270:
+      return { tl: q.tr, tr: q.br, br: q.bl, bl: q.tl };
+    default:
+      return q;
+  }
+}
+
+// The renderer composes flip first, then rotate, so expected = rotate(flip(base)).
+function expectedQuadrants(
+  degrees: number,
+  flip: "Horizontal" | "Vertical" | undefined
+): Quad {
+  return applyRotate(applyFlip(matrixBase, flip), degrees);
+}
+
+// Rotation rows, in the exact order the generator draws them. Corner and Center
+// of the same angle share expected colours (they differ only in placement, which
+// the generator's dest-origin offset compensates), so both use `degrees`.
+const matrixRotationRows: { label: string; degrees: number }[] = [
+  { label: "None", degrees: 0 },
+  { label: "Center 90", degrees: 90 },
+  { label: "Center 180", degrees: 180 },
+  { label: "Center 270", degrees: 270 },
+  { label: "Corner 90", degrees: 90 },
+  { label: "Corner 180", degrees: 180 },
+  { label: "Corner 270", degrees: 270 },
+];
+
+const matrixFlipCols: {
+  label: string;
+  flip: "Horizontal" | "Vertical" | undefined;
+}[] = [
+  { label: "None", flip: undefined },
+  { label: "Horizontal", flip: "Horizontal" },
+  { label: "Vertical", flip: "Vertical" },
+];
+
+// Layout constants — must match the generator.
+const MATRIX_S = 40;
+const MATRIX_GAP = 20;
+const MATRIX_ORIGIN_X = 40;
+const MATRIX_ORIGIN_Y = 40;
+const MATRIX_PAGE = 12;
+
+async function readCellQuadrants(
+  image: ReturnType<typeof pageImage>,
+  cx: number,
+  cy: number
+): Promise<Quad> {
+  const q = MATRIX_S / 4;
+  return {
+    tl: await readPixel(image, cx + q, cy + q),
+    tr: await readPixel(image, cx + 3 * q, cy + q),
+    bl: await readPixel(image, cx + q, cy + 3 * q),
+    br: await readPixel(image, cx + 3 * q, cy + 3 * q),
+  };
+}
+
+matrixRotationRows.forEach((rotation, row) => {
+  matrixFlipCols.forEach((flipCol, col) => {
+    test(`drawTexture matrix: rotate ${rotation.label} + flip ${flipCol.label} lands the expected quadrants`, async ({
+      page,
+    }) => {
+      await page.goto("/generator/test-api-drawing-textures");
+
+      const cx = MATRIX_ORIGIN_X + col * (MATRIX_S + MATRIX_GAP);
+      const cy = MATRIX_ORIGIN_Y + row * (MATRIX_S + MATRIX_GAP);
+
+      const actual = await readCellQuadrants(
+        pageImage(page).nth(MATRIX_PAGE),
+        cx,
+        cy
+      );
+
+      expect(actual).toEqual(
+        expectedQuadrants(rotation.degrees, flipCol.flip)
+      );
+    });
+  });
 });


### PR DESCRIPTION
Rotate/flip has been an ongoing bug-prone area, but the `drawTexture` coverage board only tested rotate-only and flip-only in isolation — never a combination, and never pixel-verified.

This adds a dedicated page (`TextureTransformMatrix`, page 12) to the `test-api-drawing-textures` generator drawing an **exhaustive 7×3 grid of every rotate × flip combination**:

- **3 flips** — None, Horizontal, Vertical
- **7 rotate states** — None, Center 90/180/270, Corner 90/180/270
- **= 21 combinations**, each verified by pixel-reads of the 4×4 quadrant fixture (no snapshots).

### Notes
- `{ rotate: N }` = Center, `{ rotateLegacy: N }` = Corner (Corner is only reachable via the deprecated option — the exhaustive matrix intentionally exercises it).
- Corner rotations pivot about the destination origin, so each Corner cell's dest origin is shifted to the cell corner that brings the rotated square back in-cell. Corner and Center of the same angle then share expected colours (they differ only in placement).
- Expected values are computed as `rotate(flip(base))`, matching the renderer's fixed **flip-then-rotate** composition — which the suite also pins down.

### Verification
- Full `testApiDrawingTextures` spec: **35/35** (14 existing + 21 matrix). `types:check` + `lint` clean.
- Sabotage-and-revert: breaking a Corner offset fails only that Corner row; swapping the expected composition order fails **exactly the 8 order-sensitive cells** (rotate 90/270 × flip H/V) while the commuting 180/standalone cells still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)