### PR TITLE
Fix flaky skin-picker transparent assertion in testApiControlsGenerator

### DIFF
--- a/tests/generators/testApiControlsGenerator/testApiControlsGenerator.spec.ts
+++ b/tests/generators/testApiControlsGenerator/testApiControlsGenerator.spec.ts
@@ -284,7 +284,10 @@ test("defineMinecraftSkinInput converts a deterministic local 64x64 skin upload"
   await page.goto("/generator/test-api-controls");
 
   await skinPicker(page).selectOption("");
-  expect(await readPixel(skinPage(page), 24, 24)).toEqual(transparent);
+  // Clearing the picker re-renders asynchronously, so poll until the skin is gone.
+  await expect
+    .poll(async () => readPixel(skinPage(page), 24, 24))
+    .toEqual(transparent);
 
   await page
     .getByLabel("Upload Minecraft skin skin file")
@@ -310,7 +313,10 @@ test("defineMinecraftSkinInput fetches and converts a routed username skin", asy
   await page.goto("/generator/test-api-controls");
 
   await skinPicker(page).selectOption("");
-  expect(await readPixel(skinPage(page), 24, 24)).toEqual(transparent);
+  // Clearing the picker re-renders asynchronously, so poll until the skin is gone.
+  await expect
+    .poll(async () => readPixel(skinPage(page), 24, 24))
+    .toEqual(transparent);
 
   await page.getByPlaceholder("Enter username").fill("FixtureUser");
   await page.getByRole("button", { name: "Fetch skin" }).click();


### PR DESCRIPTION
## Problem

The `main` CI run [29250136557](https://github.com/pixelpapercraft/pixel-papercraft-generators/actions/runs/29250136557/job/86816389244) failed on a single Playwright test:

```
testApiControlsGenerator.spec.ts
  › defineMinecraftSkinInput fetches and converts a routed username skin
  expect(await readPixel(skinPage(page), 24, 24)).toEqual(transparent)
  Expected {r:0,g:0,b:0,a:0}  Received {r:239,g:68,b:68,a:255}  // #EF4444
```

## Root cause — a timing race, not a regression

The skin picker **defaults to `Fixture`**, so the fixture skin is already rendered on page load (pixel 24,24 = `#EF4444`). Both `defineMinecraftSkinInput` tests then did:

```ts
await skinPicker(page).selectOption("");                              // clears the skin — async re-render
expect(await readPixel(skinPage(page), 24, 24)).toEqual(transparent); // read immediately, no polling
```

`selectOption("")` triggers an async re-render that clears the skin, but the next line reads the pixel synchronously. Under CI load the read wins the race and catches the still-rendered fixture skin.

The same bug existed in **both** `defineMinecraftSkinInput` tests (the deterministic-upload one and the routed-username one); the first passed this run purely by luck.

## Fix

Poll until the pixel goes transparent, matching the `.not.toEqual(transparent)` polling pattern already used elsewhere in the same tests. Test-only change.

## Verification

- Full `testApiControlsGenerator` file, `--repeat-each=3 --workers=2`: 45/45 passed.
- `npm run types:check` and `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)