### PR TITLE
V2 public surface: single builder/v2 barrel + GeneratorUI controls

### DIFF
--- a/src/builder/v2/generatorUI.test.tsx
+++ b/src/builder/v2/generatorUI.test.tsx
@@ -1,0 +1,148 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { GeneratorUI } from "./generatorUI";
+
+// Every generator's Playwright spec finds its controls with `getByLabel(…)`, so
+// the label-to-input association is these controls' real contract — not their
+// styling. These tests pin that association, and the id-vs-label distinction
+// `SelectControl` exists to support.
+
+// `for="x"` must point at the `id="x"` of a form element in the same markup.
+function labelTargetsAControl(markup: string, label: string): boolean {
+  const forMatch = markup.match(/for="([^"]+)"/);
+  if (!forMatch) {
+    return false;
+  }
+  const target = forMatch[1];
+  return (
+    markup.includes(`>${label}<`) &&
+    new RegExp(`<(input|select)[^>]*id="${target}"`).test(markup)
+  );
+}
+
+describe("GeneratorUI.BooleanControl", () => {
+  it("associates its label with the checkbox", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GeneratorUI.BooleanControl, {
+        label: "Show Folds",
+        checked: false,
+        onCheckedChange: vi.fn(),
+      })
+    );
+
+    expect(labelTargetsAControl(markup, "Show Folds")).toBe(true);
+    expect(markup).toContain('type="checkbox"');
+  });
+
+  it("reflects the checked prop", () => {
+    const checked = renderToStaticMarkup(
+      createElement(GeneratorUI.BooleanControl, {
+        label: "Show Folds",
+        checked: true,
+        onCheckedChange: vi.fn(),
+      })
+    );
+
+    expect(checked).toContain("checked=");
+  });
+});
+
+describe("GeneratorUI.SelectControl", () => {
+  it("renders an option whose id differs from its label", () => {
+    // Item's "Version" select relies on this: a `custom` id behind a display
+    // label. v1's SelectControl takes `string[]` and cannot express it, which
+    // is why this control is not delegated to v1.
+    const markup = renderToStaticMarkup(
+      createElement(GeneratorUI.SelectControl, {
+        label: "Version",
+        options: [{ id: "custom", label: "Custom Textures" }],
+        value: "custom",
+        onValueChange: vi.fn(),
+      })
+    );
+
+    expect(labelTargetsAControl(markup, "Version")).toBe(true);
+    expect(markup).toContain('<option value="custom"');
+    expect(markup).toContain(">Custom Textures</option>");
+  });
+});
+
+describe("GeneratorUI.RangeControl", () => {
+  it("associates its label with the range input and carries its bounds", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GeneratorUI.RangeControl, {
+        label: "Glint Opacity",
+        min: 0,
+        max: 255,
+        step: 1,
+        value: 76,
+        onValueChange: vi.fn(),
+      })
+    );
+
+    expect(labelTargetsAControl(markup, "Glint Opacity")).toBe(true);
+    expect(markup).toContain('type="range"');
+    expect(markup).toContain('min="0"');
+    expect(markup).toContain('max="255"');
+  });
+
+  it("shows the current value only when asked", () => {
+    const props = {
+      label: "Custom Scale (%)",
+      min: 0,
+      max: 200,
+      step: 1,
+      value: 150,
+      onValueChange: vi.fn(),
+    };
+
+    expect(
+      renderToStaticMarkup(
+        createElement(GeneratorUI.RangeControl, { ...props, showValue: true })
+      )
+    ).toContain(">150<");
+    expect(
+      renderToStaticMarkup(createElement(GeneratorUI.RangeControl, props))
+    ).not.toContain(">150<");
+  });
+});
+
+describe("GeneratorUI.ButtonControl", () => {
+  it("exposes its label as the accessible name", () => {
+    // Block and Item find these with `getByLabel("Add Item")`, which resolves
+    // through the button's aria-label rather than a <label> element.
+    const markup = renderToStaticMarkup(
+      createElement(GeneratorUI.ButtonControl, {
+        label: "Add Item",
+        onClick: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('aria-label="Add Item"');
+    expect(markup).toContain(">Add Item<");
+  });
+});
+
+describe("GeneratorUI.TextControl", () => {
+  it("renders its children", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GeneratorUI.TextControl, {
+        children: "Pick a skin to begin.",
+      })
+    );
+
+    expect(markup).toContain("<p>Pick a skin to begin.</p>");
+  });
+});
+
+describe("GeneratorUI deprecated aliases", () => {
+  it("are the same components as their new names", () => {
+    // These keep the *Input spelling working until every V2 generator is
+    // repointed; they must never drift into separate implementations.
+    expect(GeneratorUI.BooleanInput).toBe(GeneratorUI.BooleanControl);
+    expect(GeneratorUI.SelectInput).toBe(GeneratorUI.SelectControl);
+    expect(GeneratorUI.RangeInput).toBe(GeneratorUI.RangeControl);
+    expect(GeneratorUI.Text).toBe(GeneratorUI.TextControl);
+  });
+});

--- a/src/builder/v2/generatorUI.test.tsx
+++ b/src/builder/v2/generatorUI.test.tsx
@@ -126,10 +126,11 @@ describe("GeneratorUI.ButtonControl", () => {
 
 describe("GeneratorUI.TextControl", () => {
   it("renders its children", () => {
+    // JSX rather than createElement: children are this control's only prop, and
+    // passing them through createElement's props argument trips
+    // react/no-children-prop.
     const markup = renderToStaticMarkup(
-      createElement(GeneratorUI.TextControl, {
-        children: "Pick a skin to begin.",
-      })
+      <GeneratorUI.TextControl>Pick a skin to begin.</GeneratorUI.TextControl>
     );
 
     expect(markup).toContain("<p>Pick a skin to begin.</p>");

--- a/src/builder/v2/generatorUI.tsx
+++ b/src/builder/v2/generatorUI.tsx
@@ -1,52 +1,37 @@
 "use client";
 
 import React from "react";
-import {
-  Button,
-  type ButtonColor,
-  type ButtonSize,
-  type ButtonState,
-} from "@genroot/builder/ui/button/button";
+import { type ButtonColor } from "@genroot/builder/ui/button/button";
 import { Instructions } from "@genroot/builder/ui/instructions";
 import { History } from "@genroot/builder/ui/history";
 import { MediaHero } from "@genroot/builder/ui/mediaHero";
+import { AtlasControl } from "@genroot/builder/ui/controls/atlasControl";
+import { TextureControl } from "@genroot/builder/ui/controls/textureControl";
+import { BooleanControl as BooleanControlV1 } from "@genroot/builder/ui/controls/booleanControl";
+import { ButtonControl as ButtonControlV1 } from "@genroot/builder/ui/controls/buttonControl";
+import { RangeControl as RangeControlV1 } from "@genroot/builder/ui/controls/rangeControl";
+import { LoadedTextureControl } from "./loadedTextureControl";
 
-export type BooleanInputProps = {
+// V2's controls wrap v1's so both generations render identical markup while v2
+// authors get explicit, controlled props (`label`/`onValueChange`) instead of
+// v1's `id`-doubles-as-label convention. `builder/ui` is being retired; when it
+// goes, these wrappers absorb the markup and the v1 modules are deleted.
+// Generators must reach these only through `GeneratorUI` — see the eslint
+// boundary rule for `src/generators/*V2/`.
+
+export type BooleanControlProps = {
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
 };
 
-export function BooleanInput({
+export function BooleanControl({
   label,
   checked,
   onCheckedChange,
-}: BooleanInputProps): JSX.Element {
-  const inputId = React.useId();
-
+}: BooleanControlProps): JSX.Element {
   return (
-    <label
-      className="inline-flex items-center cursor-pointer"
-      htmlFor={inputId}
-    >
-      <span className="relative">
-        <span className="block w-10 h-6 bg-gray-300 rounded-full shadow-inner" />
-        <span
-          className={`absolute block w-4 h-4 mt-1 ml-1 rounded-full inset-y-0 left-0 focus-within:shadow-outline transition-transform duration-50 ease-in-out ${
-            checked ? "bg-blue-500 transform translate-x-full" : "bg-white"
-          }`}
-        >
-          <input
-            id={inputId}
-            type="checkbox"
-            className="absolute opacity-0 w-0 h-0"
-            checked={checked}
-            onChange={(event) => onCheckedChange(event.currentTarget.checked)}
-          />
-        </span>
-      </span>
-      <span className="ml-3">{label}</span>
-    </label>
+    <BooleanControlV1 id={label} checked={checked} onChange={onCheckedChange} />
   );
 }
 
@@ -55,23 +40,27 @@ export type SelectOption = {
   label: string;
 };
 
-export type SelectInputProps = {
+export type SelectControlProps = {
   label: string;
   options: SelectOption[];
   value: string;
   onValueChange: (value: string) => void;
 };
 
-export function SelectInput({
+// Not delegated to v1's `SelectControl`: that one takes `string[]`, so an
+// option's id and label are always the same. V2 authors need them to differ
+// (Item's "Version" select has a `custom` id behind a display label), so this
+// keeps the richer `SelectOption[]` API and reproduces v1's markup directly.
+export function SelectControl({
   label,
   options,
   value,
   onValueChange,
-}: SelectInputProps): JSX.Element {
+}: SelectControlProps): JSX.Element {
   const inputId = React.useId();
 
   return (
-    <div>
+    <div className="mb-4">
       <label className="font-bold mb-1 block" htmlFor={inputId}>
         {label}
       </label>
@@ -91,92 +80,79 @@ export function SelectInput({
   );
 }
 
-export type RangeInputProps = {
+export type RangeControlProps = {
   label: string;
   min: number;
   max: number;
   step: number;
   value: number;
-  valueLabel?: React.ReactNode;
+  showValue?: boolean;
   onValueChange: (value: number) => void;
 };
 
-export function RangeInput({
+export function RangeControl({
   label,
   min,
   max,
   step,
   value,
-  valueLabel,
+  showValue,
   onValueChange,
-}: RangeInputProps): JSX.Element {
-  const inputId = React.useId();
-
+}: RangeControlProps): JSX.Element {
   return (
-    <div>
-      <label className="font-bold mb-1 block" htmlFor={inputId}>
-        {label}
-      </label>
-      <input
-        id={inputId}
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(event) => onValueChange(Number(event.currentTarget.value))}
-      />
-      {valueLabel ? <span className="ml-2">{valueLabel}</span> : null}
+    <RangeControlV1
+      id={label}
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      showValue={showValue}
+      onChange={onValueChange}
+    />
+  );
+}
+
+export type ButtonControlProps = {
+  label: string;
+  color?: ButtonColor;
+  onClick: () => void;
+};
+
+export function ButtonControl({
+  label,
+  color,
+  onClick,
+}: ButtonControlProps): JSX.Element {
+  return <ButtonControlV1 id={label} color={color} onClick={onClick} />;
+}
+
+export type TextControlProps = {
+  children: React.ReactNode;
+};
+
+// v1's `TextControl` takes a `text: string`, so it can't carry the rich
+// children v2 authors pass; this reproduces its wrapper instead.
+export function TextControl({ children }: TextControlProps): JSX.Element {
+  return (
+    <div className="mb-4">
+      <p>{children}</p>
     </div>
   );
-}
-
-export type ButtonProps = {
-  children: React.ReactNode;
-  title: string;
-  color?: ButtonColor;
-  size?: ButtonSize;
-  state?: ButtonState;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-};
-
-export function GeneratorButton({
-  children,
-  title,
-  color,
-  size,
-  state,
-  onClick,
-}: ButtonProps): JSX.Element {
-  return (
-    <Button
-      title={title}
-      color={color}
-      size={size}
-      state={state}
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  );
-}
-
-export type TextProps = {
-  children: React.ReactNode;
-};
-
-export function Text({ children }: TextProps): JSX.Element {
-  return <p>{children}</p>;
 }
 
 // V2 controls are controlled React components. They deliberately receive no
 // generator model or renderer state; authors own state and arrange controls.
 export const GeneratorUI = {
-  BooleanInput,
-  SelectInput,
-  RangeInput,
-  Button: GeneratorButton,
-  Text,
+  BooleanControl,
+  SelectControl,
+  RangeControl,
+  ButtonControl,
+  TextControl,
+  AtlasControl,
+  TextureControl,
+  // Owns its own texture-choice loading, so authors never see the load
+  // lifecycle. See the framework-owned loading plan.
+  LoadedTextureControl,
   // Same collapsible markdown panel v1 renders from `GeneratorDef.instructions`.
   // V2 has no `instructions` field on `GeneratorV2` — authors place it
   // themselves, wherever it fits their custom UI layout.
@@ -186,4 +162,16 @@ export const GeneratorUI = {
   MediaHero,
   // Same Updates list v1 renders below the generator surface.
   History,
+
+  // Deprecated `*Input` names, kept so this slice changes no generator. Each
+  // is the same component under its new name; they are removed once every V2
+  // generator is repointed.
+  /** @deprecated Use `BooleanControl`. */
+  BooleanInput: BooleanControl,
+  /** @deprecated Use `SelectControl`. */
+  SelectInput: SelectControl,
+  /** @deprecated Use `RangeControl`. */
+  RangeInput: RangeControl,
+  /** @deprecated Use `TextControl`. */
+  Text: TextControl,
 };

--- a/src/builder/v2/index.ts
+++ b/src/builder/v2/index.ts
@@ -1,0 +1,80 @@
+// The entire public surface a V2 generator author may import.
+//
+// V2 generators must import from `@genroot/builder/v2` and nowhere else inside
+// `src/builder` — no `@genroot/builder/ui/*`, no `@genroot/builder/modules/*`.
+// Both of those directories are being retired once every generator is migrated,
+// and an eslint boundary rule enforces this for `src/generators/*V2/`.
+//
+// Two runtime surfaces only:
+//   - `GeneratorRenderer` — renders the generator's pages
+//   - `GeneratorUI`       — every pre-built, generic UI control
+//
+// Everything else exported here is the type vocabulary those two need. Controls
+// that are *not* generic — Minecraft skin pickers, tint selectors, glint — are
+// deliberately absent: they are generator content, and live under
+// `src/generators/_common/`.
+
+export { GeneratorRenderer } from "./generatorRenderer";
+export { GeneratorUI } from "./generatorUI";
+
+export type {
+  BooleanControlProps,
+  SelectControlProps,
+  SelectOption,
+  RangeControlProps,
+  ButtonControlProps,
+  TextControlProps,
+} from "./generatorUI";
+
+// The V2 generator contract.
+export type {
+  GeneratorV2,
+  GeneratorDefV2,
+  RenderContext,
+  RegionClickHandler,
+} from "./generatorV2";
+
+// Definition shapes an author declares (images, textures, thumbnail, …).
+export type {
+  ImageDef,
+  TextureDef,
+  ThumbnailDef,
+  InstructionsDef,
+  VideoDef,
+  HistoryDef,
+} from "@genroot/builder/modules/generatorDef";
+
+export type { Texture } from "@genroot/builder/modules/texture";
+export type { TexturePlugin } from "@genroot/builder/modules/generator";
+export type { Color } from "@genroot/builder/modules/canvasWithContext";
+
+// The geometry and drawing vocabulary `RenderContext`'s methods speak.
+export type {
+  Point,
+  Position,
+  Dimensions,
+  Region,
+  RegionLegacy,
+  Rectangle,
+} from "@genroot/builder/modules/renderers/types";
+export type {
+  DrawTextureOptions,
+  Blend,
+} from "@genroot/builder/modules/renderers/drawTexture";
+
+// Page sizes.
+export { A4 } from "@genroot/builder/modules/modelPage";
+
+// Texture-picker state. Generic picker plumbing: the selection model plus its
+// serialization, which Block and Item drive through their own pickers.
+export {
+  type SelectedTexture,
+  encodeSelectedTextures,
+  decodeSelectedTextures,
+  decodeSelectedTexture,
+} from "@genroot/builder/ui/texturePicker/selectedTexture";
+export { type Flip, makeNextFlip } from "@genroot/builder/ui/texturePicker/flip";
+export {
+  type Rotation,
+  rotationToDegrees,
+} from "@genroot/builder/ui/texturePicker/rotation";


### PR DESCRIPTION
First slice of narrowing the V2 generator author surface to just `GeneratorRenderer` and `GeneratorUI`, so `src/builder/ui/` and `src/builder/modules/` can eventually be retired. Based on `generator-v2-prototype` — the whole V2 world lives only there.

## Scope

Builder only. **No generator is repointed in this PR**, so nothing breaks: the old import paths still exist and the `*Input` names still resolve.

- **`src/builder/v2/index.ts` (new)** — the single barrel a V2 author imports from: `GeneratorRenderer`, `GeneratorUI`, and the type vocabulary they need (`GeneratorDefV2`, `RenderContext`, `Texture`, `ImageDef`, `TexturePlugin`, `DrawTextureOptions`, `A4`, the texture-picker selection model, …).
- **`GeneratorUI` absorbs the generic controls** — `AtlasControl`, `TextureControl` and `LoadedTextureControl` join it, and the duplicated controls unify.

## Why the controls needed unifying

`GeneratorUI` already duplicated v1's controls, and the V2 generators were **split across both**: Example/Action Figure/Armor/Character used `GeneratorUI.BooleanInput`, while Dalek/Axolotl/Block/Cape/Cat imported v1's `BooleanControl`. The two rendered different wrapper spacing (`mb-4`/`mt-3`). Same for `RangeInput` vs `RangeControl`.

They now unify on one control each, keeping v2's explicit props (`label`/`onCheckedChange`) but **delegating to the v1 component**, so both generations render identical markup and v2 sidebars keep looking like v1's. `SelectControl` is the one that isn't delegated — v1's takes `string[]`, so an option's id and label are always equal, and Item's "Version" select needs them to differ.

The `*Input` names remain as deprecated aliases pointing at the same components, so this slice repoints no generator. They're removed in the last slice, once every generator is on the barrel.

## Verification

- **353/353 Playwright** (full suite, v1 + v2) — this slice changes sidebar markup for several generators, so the whole suite ran, not just the focused set. Snapshots only capture `generator-page-image`, so what actually needed proving was the `getByLabel` contract, and it holds.
- **140/140 unit**, including 8 new `GeneratorUI` tests pinning the label-to-input association every spec depends on, and the id-vs-label case `SelectControl` exists to support.
- `types:check` and `lint` clean.

## Next slices

B–E repoint the 13 generators onto the barrel (3 simple → 7 Minecraft-skin → Armor → Block+Item); F adds an ESLint rule forbidding `@genroot/builder/{ui,modules}/*` under `src/generators/*V2/` and drops the deprecated aliases. Plan lives in the vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)