### PR TITLE
V2 surface: repoint Dalek, Cape and Elytra, and Cat onto the barrel

### DIFF
--- a/src/generators/dalekModDalekV2/dalekModDalekV2Generator.tsx
+++ b/src/generators/dalekModDalekV2/dalekModDalekV2Generator.tsx
@@ -2,21 +2,17 @@
 
 import React from "react";
 import {
-  type ImageDef,
-  type InstructionsDef,
-  type TextureDef,
-  type ThumbnailDef,
-} from "@genroot/builder/modules/generatorDef";
-import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type ImageDef,
+  type InstructionsDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { LoadedTextureControl } from "@genroot/builder/v2/loadedTextureControl";
-import { BooleanControl } from "@genroot/builder/ui/controls/booleanControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+} from "@genroot/builder/v2";
 
 import thumbnailImage from "./thumbnail/v2-thumbnail-256.jpeg";
 import dalekImage from "./instructions/dalek.jpeg";
@@ -564,7 +560,7 @@ function Component(): JSX.Element {
           <div className="w-full bg-gray-100 p-8 space-y-4">
             <GeneratorUI.Instructions markdown={instructions} />
 
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Skin"
               definitions={dalekTextures}
               standardWidth={128}
@@ -575,10 +571,10 @@ function Component(): JSX.Element {
               onChange={setSkinTexture}
             />
 
-            <BooleanControl
-              id="Show Colors"
+            <GeneratorUI.BooleanControl
+              label="Show Colors"
               checked={showColors}
-              onChange={setShowColors}
+              onCheckedChange={setShowColors}
             />
           </div>
         </div>

--- a/src/generators/minecraftCapeAndElytraV2/minecraftCapeAndElytraV2Generator.tsx
+++ b/src/generators/minecraftCapeAndElytraV2/minecraftCapeAndElytraV2Generator.tsx
@@ -1,22 +1,18 @@
 "use client";
 
 import React from "react";
-import type {
-  ImageDef,
-  HistoryDef,
-  TextureDef,
-  ThumbnailDef,
-} from "@genroot/builder/modules/generatorDef";
-import { type Texture } from "@genroot/builder/modules/texture";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type HistoryDef,
+  type ImageDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { LoadedTextureControl } from "@genroot/builder/v2/loadedTextureControl";
-import { BooleanControl } from "@genroot/builder/ui/controls/booleanControl";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+} from "@genroot/builder/v2";
 
 import thumbnailImage from "./thumbnail/thumbnail-256.jpeg";
 import foregroundImage from "./images/Foreground.png";
@@ -375,7 +371,7 @@ function Component(): JSX.Element {
       <div className="lg:flex gap-8">
         <div className="flex-1 min-w-0" data-testid="generator-sidebar">
           <div className="w-full bg-gray-100 p-8 space-y-4">
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Cape"
               definitions={textures}
               choices={choices}
@@ -384,15 +380,15 @@ function Component(): JSX.Element {
               initialTextureId="Cape"
               onChange={setCapeTexture}
             />
-            <BooleanControl
-              id="Show Folds"
+            <GeneratorUI.BooleanControl
+              label="Show Folds"
               checked={showFolds}
-              onChange={setShowFolds}
+              onCheckedChange={setShowFolds}
             />
-            <BooleanControl
-              id="Show Labels"
+            <GeneratorUI.BooleanControl
+              label="Show Labels"
               checked={showLabels}
-              onChange={setShowLabels}
+              onCheckedChange={setShowLabels}
             />
           </div>
         </div>

--- a/src/generators/minecraftCatV2/minecraftCatV2Generator.tsx
+++ b/src/generators/minecraftCatV2/minecraftCatV2Generator.tsx
@@ -1,22 +1,18 @@
 "use client";
 
 import React from "react";
-import type {
-  ImageDef,
-  HistoryDef,
-  TextureDef,
-  ThumbnailDef,
-} from "@genroot/builder/modules/generatorDef";
-import { type Texture } from "@genroot/builder/modules/texture";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type HistoryDef,
+  type ImageDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { LoadedTextureControl } from "@genroot/builder/v2/loadedTextureControl";
-import { BooleanControl } from "@genroot/builder/ui/controls/booleanControl";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+} from "@genroot/builder/v2";
 import { TintSelector } from "@genroot/generators/_common/tintSelector/tintSelector";
 import { catTintChoiceGroups } from "@genroot/generators/_common/tintSelector/tints";
 
@@ -423,7 +419,7 @@ function Component(): JSX.Element {
       <div className="lg:flex gap-8">
         <div className="flex-1 min-w-0" data-testid="generator-sidebar">
           <div className="w-full bg-gray-100 p-8 space-y-4">
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Cat"
               definitions={textures}
               choices={catChoices}
@@ -432,7 +428,7 @@ function Component(): JSX.Element {
               initialTextureId="Cat"
               onChange={setCatTexture}
             />
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Collar"
               definitions={textures}
               choices={collarChoices}
@@ -447,15 +443,15 @@ function Component(): JSX.Element {
               choiceGroups={catTintChoiceGroups}
               includeNoTint={false}
             />
-            <BooleanControl
-              id="Show Folds"
+            <GeneratorUI.BooleanControl
+              label="Show Folds"
               checked={showFolds}
-              onChange={setShowFolds}
+              onCheckedChange={setShowFolds}
             />
-            <BooleanControl
-              id="Show Labels"
+            <GeneratorUI.BooleanControl
+              label="Show Labels"
               checked={showLabels}
-              onChange={setShowLabels}
+              onCheckedChange={setShowLabels}
             />
           </div>
         </div>


### PR DESCRIPTION
Slice B of narrowing the V2 author surface. Follows #63, which built `@genroot/builder/v2`.

## Scope

The first three generators to import **only** from the barrel. Each drops from five or six builder import lines to one, and reaches its controls through `GeneratorUI` instead of `builder/ui`:

```diff
-} from "@genroot/builder/modules/generatorDef";
-import { type Texture } from "@genroot/builder/modules/texture";
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { LoadedTextureControl } from "@genroot/builder/v2/loadedTextureControl";
-import { BooleanControl } from "@genroot/builder/ui/controls/booleanControl";
+} from "@genroot/builder/v2";
```

Dalek, Cape and Elytra, and Cat are the simplest cases — booleans and types only, no Minecraft skin picker, no texture-picker state — which makes them the first real test of the barrel from the generator side. `grep` confirms none of the three names `@genroot/builder/ui` or `@genroot/builder/modules` any more.

The `BooleanControl` call sites move from v1's `id`/`onChange` to the V2 control's `label`/`onCheckedChange`. `GeneratorUI.BooleanControl` delegates to the v1 component (see #63), so the rendered markup is unchanged.

## Verification

Import-only: no render function, no geometry, and no test changed. So the unchanged V1 and V2 suites passing against the same byte-identical baselines is the proof of no behaviour change — any snapshot diff at all would be a real regression.

- **40/40 Playwright** — all three generators' V1 *and* V2 suites.
- CI's quality sequence run as one command (`types:check && lint && test:unit`), exit 0.

## Next

C repoints the 7 Minecraft-skin generators (adding the `_common/skins/` aliases), D Armor, E Block + Item; F adds the ESLint boundary rule and drops the deprecated `*Input` aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)