### PR TITLE
V2 surface: repoint the seven Minecraft-skin generators onto the barrel

### DIFF
--- a/src/generators/_common/skins/skinControl.ts
+++ b/src/generators/_common/skins/skinControl.ts
@@ -1,0 +1,20 @@
+// The Minecraft skin picker and its input value, for V2 generators.
+//
+// These are Minecraft-specific, not framework: `@genroot/builder/v2` carries
+// only generic controls, so anything that knows what a Minecraft skin is
+// belongs with the generators — the same reasoning that already puts
+// `_common/tintSelector` and `_common/plugins/glint` here.
+//
+// Re-exports rather than a move. V1's `controls.tsx`, `generator.ts` and
+// `modelControls.ts` still import these same modules out of `src/builder`, and
+// relocating the files while V1 lives would invert the dependency: the builder
+// framework would import from generator content. When `builder/ui` and
+// `builder/modules` retire, the implementations move here and these re-exports
+// become the definitions — at which point no generator has to change again.
+export { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
+export {
+  getDefaultMinecraftSkinInputValue,
+  type MinecraftSkinInputValue,
+  type MinecraftModelType,
+  type MinecraftSkinSelection,
+} from "@genroot/builder/modules/minecraftSkinInputValue";

--- a/src/generators/amogusBendableV2/amogusBendableV2Generator.tsx
+++ b/src/generators/amogusBendableV2/amogusBendableV2Generator.tsx
@@ -2,25 +2,23 @@
 
 import React from "react";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
+  type GeneratorDefV2,
+  type GeneratorV2,
   type ImageDef,
   type InstructionsDef,
+  type RenderContext,
+  type Texture,
   type TextureDef,
   type ThumbnailDef,
   type VideoDef,
-} from "@genroot/builder/modules/generatorDef";
+} from "@genroot/builder/v2";
 import {
-  type GeneratorDefV2,
-  type GeneratorV2,
-  type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { type Texture } from "@genroot/builder/modules/texture";
-import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { makeDefaultMinecraftSkinPresetOptions } from "../_common/skins/options";
 
 import thumbnailImage from "./thumbnail/v2-thumbnail-256.jpeg";

--- a/src/generators/exampleV2/exampleV2Generator.tsx
+++ b/src/generators/exampleV2/exampleV2Generator.tsx
@@ -2,23 +2,21 @@
 
 import React from "react";
 import {
-  type ImageDef,
-  type InstructionsDef,
-  type TextureDef,
-} from "@genroot/builder/modules/generatorDef";
-import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type ImageDef,
+  type InstructionsDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+} from "@genroot/builder/v2";
 import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { makeDefaultMinecraftSkinPresetOptions } from "../_common/skins/options";
 
 import backgroundImage from "./images/Background.png";

--- a/src/generators/minecraftActionFigureV2/minecraftActionFigureV2Generator.tsx
+++ b/src/generators/minecraftActionFigureV2/minecraftActionFigureV2Generator.tsx
@@ -2,24 +2,22 @@
 
 import React from "react";
 import {
-  type ImageDef,
-  type ThumbnailDef,
-  type TextureDef,
-} from "@genroot/builder/modules/generatorDef";
-import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type ImageDef,
   type RegionClickHandler,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+} from "@genroot/builder/v2";
 import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { steve, alex } from "../_common/minecraftCharacter";
 import { type Dimensions, Minecraft } from "../_common/minecraft";
 import { makeDefaultMinecraftSkinPresetOptions } from "../_common/skins/options";

--- a/src/generators/minecraftAllayCharacterV2/minecraftAllayCharacterV2Generator.tsx
+++ b/src/generators/minecraftAllayCharacterV2/minecraftAllayCharacterV2Generator.tsx
@@ -2,24 +2,22 @@
 
 import React from "react";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
+  type GeneratorDefV2,
+  type GeneratorV2,
   type ImageDef,
+  type RenderContext,
+  type Texture,
   type TextureDef,
   type ThumbnailDef,
   type VideoDef,
-} from "@genroot/builder/modules/generatorDef";
+} from "@genroot/builder/v2";
 import {
-  type GeneratorDefV2,
-  type GeneratorV2,
-  type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { type Texture } from "@genroot/builder/modules/texture";
-import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { steve, alex } from "../_common/minecraftCharacter";
 import { makeDefaultMinecraftSkinPresetOptions } from "../_common/skins/options";
 

--- a/src/generators/minecraftAxolotlCharacterV2/minecraftAxolotlCharacterV2Generator.tsx
+++ b/src/generators/minecraftAxolotlCharacterV2/minecraftAxolotlCharacterV2Generator.tsx
@@ -1,29 +1,24 @@
 "use client";
 
 import React from "react";
-import type {
-  ImageDef,
-  HistoryDef,
-  ThumbnailDef,
-  TextureDef,
-  VideoDef,
-} from "@genroot/builder/modules/generatorDef";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type HistoryDef,
+  type ImageDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { LoadedTextureControl } from "@genroot/builder/v2/loadedTextureControl";
-import { BooleanControl } from "@genroot/builder/ui/controls/booleanControl";
-import { RangeControl } from "@genroot/builder/ui/controls/rangeControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+  type VideoDef,
+} from "@genroot/builder/v2";
 import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import {
   type Cuboid,
   type Layer,
@@ -534,7 +529,7 @@ function Component(): JSX.Element {
               onChange={setSkinTexture}
             />
 
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Head Fins Texture"
               definitions={textures}
               standardWidth={64}
@@ -545,7 +540,7 @@ function Component(): JSX.Element {
               onChange={setHeadFinsTexture}
             />
 
-            <LoadedTextureControl
+            <GeneratorUI.LoadedTextureControl
               id="Tail Fins Texture"
               definitions={textures}
               standardWidth={64}
@@ -556,28 +551,28 @@ function Component(): JSX.Element {
               onChange={setTailFinsTexture}
             />
 
-            <BooleanControl
-              id="Show Folds"
+            <GeneratorUI.BooleanControl
+              label="Show Folds"
               checked={showFolds}
-              onChange={setShowFolds}
+              onCheckedChange={setShowFolds}
             />
-            <BooleanControl
-              id="Show Labels"
+            <GeneratorUI.BooleanControl
+              label="Show Labels"
               checked={showLabels}
-              onChange={setShowLabels}
+              onCheckedChange={setShowLabels}
             />
-            <BooleanControl
-              id="Show Overlay"
+            <GeneratorUI.BooleanControl
+              label="Show Overlay"
               checked={showOverlay}
-              onChange={setShowOverlay}
+              onCheckedChange={setShowOverlay}
             />
-            <RangeControl
-              id="Axolotl Face"
+            <GeneratorUI.RangeControl
+              label="Axolotl Face"
               min={0}
               max={5}
               step={1}
               value={faceStretch}
-              onChange={setFaceStretch}
+              onValueChange={setFaceStretch}
             />
           </div>
         </div>

--- a/src/generators/minecraftBeeCharacterV2/minecraftBeeCharacterV2Generator.tsx
+++ b/src/generators/minecraftBeeCharacterV2/minecraftBeeCharacterV2Generator.tsx
@@ -1,27 +1,24 @@
 "use client";
 
 import React from "react";
-import type {
-  ImageDef,
-  HistoryDef,
-  ThumbnailDef,
-  TextureDef,
-  VideoDef,
-} from "@genroot/builder/modules/generatorDef";
 import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type HistoryDef,
+  type ImageDef,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { RangeControl } from "@genroot/builder/ui/controls/rangeControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+  type VideoDef,
+} from "@genroot/builder/v2";
 import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { steve, alex } from "@genroot/generators/_common/minecraftCharacter";
 
 import thumbnailImage from "./thumbnail/thumbnail-256.jpeg";
@@ -596,13 +593,13 @@ function Component(): JSX.Element {
               onValueChange={setSkin1Value}
               onChange={setSkin1Texture}
             />
-            <RangeControl
-              id="Head Size 1"
+            <GeneratorUI.RangeControl
+              label="Head Size 1"
               min={0}
               max={10}
               step={1}
               value={headMultiplier1}
-              onChange={setHeadMultiplier1}
+              onValueChange={setHeadMultiplier1}
             />
 
             <MinecraftSkinControl
@@ -616,13 +613,13 @@ function Component(): JSX.Element {
               onValueChange={setSkin2Value}
               onChange={setSkin2Texture}
             />
-            <RangeControl
-              id="Head Size 2"
+            <GeneratorUI.RangeControl
+              label="Head Size 2"
               min={0}
               max={10}
               step={1}
               value={headMultiplier2}
-              onChange={setHeadMultiplier2}
+              onValueChange={setHeadMultiplier2}
             />
           </div>
         </div>

--- a/src/generators/minecraftCharacterV2/minecraftCharacterV2Generator.tsx
+++ b/src/generators/minecraftCharacterV2/minecraftCharacterV2Generator.tsx
@@ -2,25 +2,23 @@
 
 import React from "react";
 import {
-  type ImageDef,
-  type InstructionsDef,
-  type ThumbnailDef,
-  type TextureDef,
-} from "@genroot/builder/modules/generatorDef";
-import {
+  GeneratorRenderer,
+  GeneratorUI,
   type GeneratorDefV2,
   type GeneratorV2,
+  type ImageDef,
+  type InstructionsDef,
   type RegionClickHandler,
   type RenderContext,
-} from "@genroot/builder/v2/generatorV2";
-import { GeneratorRenderer } from "@genroot/builder/v2/generatorRenderer";
-import { GeneratorUI } from "@genroot/builder/v2/generatorUI";
-import { MinecraftSkinControl } from "@genroot/builder/ui/controls/minecraftSkinControl";
-import { type Texture } from "@genroot/builder/modules/texture";
+  type Texture,
+  type TextureDef,
+  type ThumbnailDef,
+} from "@genroot/builder/v2";
 import {
+  MinecraftSkinControl,
   getDefaultMinecraftSkinInputValue,
   type MinecraftSkinInputValue,
-} from "@genroot/builder/modules/minecraftSkinInputValue";
+} from "../_common/skins/skinControl";
 import { steve, alex } from "../_common/minecraftCharacter";
 import { type Dimensions, Minecraft } from "../_common/minecraft";
 import { makeDefaultMinecraftSkinPresetOptions } from "../_common/skins/options";


### PR DESCRIPTION
Slice C of narrowing the V2 author surface. Follows #63 (the barrel) and #64 (the first three generators).

## Scope

Repoints the seven generators that use the Minecraft skin picker: **Amogus Bendable, Example, Action Figure, Allay, Axolotl, Bee, Character**.

After this, **only Armor, Block and Item still name `builder/ui` or `builder/modules`** — those are slices D and E.

## The Minecraft-specific question

`MinecraftSkinControl` and `minecraftSkinInputValue` are Minecraft-specific, not framework. By the V2 boundary they belong with the generators — the same reasoning that already puts `_common/tintSelector` and `_common/plugins/glint` there. So they're now reached through a new **`_common/skins/skinControl.ts`**.

That file **re-exports rather than moves** them, deliberately: v1's `controls.tsx`, `generator.ts` and `modelControls.ts` still import the same modules out of `src/builder`, and relocating the files while v1 lives would **invert the dependency** — the builder framework importing generator content. When `builder/ui` and `builder/modules` retire, the implementations move into that file and these re-exports become the definitions, at which point no generator has to change again.

The alternative (give V2 its own copy, leave v1's in place) is what produced the stale, diverged `_common/texturePicker/` orphan that's still sitting unused on `main` — so it was avoided on purpose.

## Also

Axolotl and Bee move their `BooleanControl`/`RangeControl` call sites onto `GeneratorUI`. Those delegate to the v1 components (see #63), so the rendered markup is unchanged.

## Verification

Import-only: no render function, no geometry, and no test changed. The unchanged V1 and V2 suites passing against the same byte-identical baselines is the proof — any snapshot diff would be a real regression.

- **108/108 Playwright** — all seven generators' V1 *and* V2 suites.
- CI's quality sequence run as one command (`types:check && lint && test:unit`), exit 0.

## Next

D repoints Armor; E repoints Block + Item (texture-picker state, `A4`, their local render adapters); F adds the ESLint rule forbidding `@genroot/builder/{ui,modules}/*` under `src/generators/*V2/` and drops the deprecated `*Input` aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)