### PR TITLE
V2 surface: lock the import boundary with an eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,37 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   root: true,
+  overrides: [
+    {
+      // V2 generators have exactly one builder-facing surface:
+      // `@genroot/builder/v2`, which exports GeneratorRenderer, GeneratorUI
+      // and the shared types. `builder/ui` and `builder/modules` are v1's and
+      // are being retired as generators migrate, so nothing under a *V2
+      // directory may name them — including type-only imports, which is how
+      // most of them leaked in the first place.
+      //
+      // Minecraft-specific controls are not in the V2 surface by design: they
+      // are generator content, and live under `src/generators/_common/`.
+      files: ["src/generators/*V2/**"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: [
+                  "@genroot/builder/ui",
+                  "@genroot/builder/ui/*",
+                  "@genroot/builder/modules",
+                  "@genroot/builder/modules/*",
+                ],
+                message:
+                  "V2 generators import only from @genroot/builder/v2 (GeneratorRenderer, GeneratorUI, and the V2 types). builder/ui and builder/modules are v1's and are being retired. Minecraft-specific controls live in src/generators/_common/.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@ Read and follow rules from any category whose "Read when" keywords match your cu
   - Shared contracts and framework behavior can live in `src/builder`.
   - Generator-owned assets, version registries, and other content should stay under `src/generators`, typically in `_common` or the specific generator directory.
 
+## V2 generator surface
+
+- A V2 generator (`src/generators/*V2/`) imports from exactly one place inside `src/builder`: the `@genroot/builder/v2` barrel. It exports two runtime surfaces — `GeneratorRenderer` and `GeneratorUI` — plus the shared type vocabulary.
+- **Never import `@genroot/builder/ui/*` or `@genroot/builder/modules/*` from a V2 generator**, including type-only imports. Those are v1's and are being retired once every generator is migrated. An eslint rule enforces this; if you find yourself wanting to add an exception, add the export to the barrel instead.
+- Every pre-built generic control is reached through `GeneratorUI` (`GeneratorUI.BooleanControl`, `GeneratorUI.LoadedTextureControl`, …), not imported directly.
+- Controls that are **not** generic — anything that knows what a Minecraft skin, tint, or glint is — are generator content, not framework. They live under `src/generators/_common/` (e.g. `_common/skins/skinControl`, `_common/tintSelector`, `_common/plugins/glint`) and are deliberately absent from `GeneratorUI`.
+- When migrating a generator to V2, copying an existing V2 generator as a template is fine — but it is also how leaks come back, so run `npm run lint` before assuming the imports are right.
+
 ## Verification
 
 - Use a test-driven mindset for all work.

--- a/src/builder/v2/generatorUI.test.tsx
+++ b/src/builder/v2/generatorUI.test.tsx
@@ -137,13 +137,24 @@ describe("GeneratorUI.TextControl", () => {
   });
 });
 
-describe("GeneratorUI deprecated aliases", () => {
-  it("are the same components as their new names", () => {
-    // These keep the *Input spelling working until every V2 generator is
-    // repointed; they must never drift into separate implementations.
-    expect(GeneratorUI.BooleanInput).toBe(GeneratorUI.BooleanControl);
-    expect(GeneratorUI.SelectInput).toBe(GeneratorUI.SelectControl);
-    expect(GeneratorUI.RangeInput).toBe(GeneratorUI.RangeControl);
-    expect(GeneratorUI.Text).toBe(GeneratorUI.TextControl);
+describe("GeneratorUI surface", () => {
+  it("exposes exactly the members V2 authors may use", () => {
+    // GeneratorUI is one of only two runtime surfaces a V2 generator imports,
+    // so its member list is a public contract rather than an implementation
+    // detail. Pinning it means adding or removing a control is a deliberate
+    // edit here, and it catches the deprecated *Input aliases coming back.
+    expect(Object.keys(GeneratorUI).sort()).toEqual([
+      "AtlasControl",
+      "BooleanControl",
+      "ButtonControl",
+      "History",
+      "Instructions",
+      "LoadedTextureControl",
+      "MediaHero",
+      "RangeControl",
+      "SelectControl",
+      "TextControl",
+      "TextureControl",
+    ]);
   });
 });

--- a/src/builder/v2/generatorUI.tsx
+++ b/src/builder/v2/generatorUI.tsx
@@ -162,16 +162,4 @@ export const GeneratorUI = {
   MediaHero,
   // Same Updates list v1 renders below the generator surface.
   History,
-
-  // Deprecated `*Input` names, kept so this slice changes no generator. Each
-  // is the same component under its new name; they are removed once every V2
-  // generator is repointed.
-  /** @deprecated Use `BooleanControl`. */
-  BooleanInput: BooleanControl,
-  /** @deprecated Use `SelectControl`. */
-  SelectInput: SelectControl,
-  /** @deprecated Use `RangeControl`. */
-  RangeInput: RangeControl,
-  /** @deprecated Use `TextControl`. */
-  Text: TextControl,
 };

--- a/src/generators/amogusBendableV2/amogusBendableV2Generator.tsx
+++ b/src/generators/amogusBendableV2/amogusBendableV2Generator.tsx
@@ -196,7 +196,7 @@ function Component(): JSX.Element {
           <div className="w-full bg-gray-100 p-8 space-y-4">
             <GeneratorUI.Instructions markdown={instructions} />
 
-            <GeneratorUI.SelectInput
+            <GeneratorUI.SelectControl
               label="Color"
               options={colorOptions}
               value={color}

--- a/src/generators/exampleV2/exampleV2Generator.tsx
+++ b/src/generators/exampleV2/exampleV2Generator.tsx
@@ -140,7 +140,7 @@ function Component(): JSX.Element {
             onChange={setSkinTexture}
           />
 
-          <GeneratorUI.BooleanInput
+          <GeneratorUI.BooleanControl
             label="Show Folds"
             checked={showFolds}
             onCheckedChange={setShowFolds}

--- a/src/generators/minecraftActionFigureV2/minecraftActionFigureV2Generator.tsx
+++ b/src/generators/minecraftActionFigureV2/minecraftActionFigureV2Generator.tsx
@@ -575,28 +575,28 @@ function Component(): JSX.Element {
               onChange={setSkinTexture}
             />
 
-            <GeneratorUI.BooleanInput
+            <GeneratorUI.BooleanControl
               label="Show Folds"
               checked={showFolds}
               onCheckedChange={setShowFolds}
             />
 
-            <GeneratorUI.BooleanInput
+            <GeneratorUI.BooleanControl
               label="Show Labels"
               checked={showLabels}
               onCheckedChange={setShowLabels}
             />
 
-            <GeneratorUI.BooleanInput
+            <GeneratorUI.BooleanControl
               label="Hand Notches"
               checked={handNotches}
               onCheckedChange={setHandNotches}
             />
 
-            <GeneratorUI.Text>
+            <GeneratorUI.TextControl>
               Click in the papercraft template to turn on and off the overlay
               for each part.
-            </GeneratorUI.Text>
+            </GeneratorUI.TextControl>
           </div>
         </div>
 

--- a/src/generators/minecraftCharacterV2/minecraftCharacterV2Generator.tsx
+++ b/src/generators/minecraftCharacterV2/minecraftCharacterV2Generator.tsx
@@ -375,22 +375,22 @@ function Component(): JSX.Element {
               onChange={setSkinTexture}
             />
 
-            <GeneratorUI.BooleanInput
+            <GeneratorUI.BooleanControl
               label="Show Folds"
               checked={showFolds}
               onCheckedChange={setShowFolds}
             />
 
-            <GeneratorUI.BooleanInput
+            <GeneratorUI.BooleanControl
               label="Show Labels"
               checked={showLabels}
               onCheckedChange={setShowLabels}
             />
 
-            <GeneratorUI.Text>
+            <GeneratorUI.TextControl>
               Click in the papercraft template to turn on and off the overlay
               for each part.
-            </GeneratorUI.Text>
+            </GeneratorUI.TextControl>
           </div>
         </div>
 


### PR DESCRIPTION
Final slice of narrowing the V2 author surface. Follows #63, #64, #65, #66 and #67.

## Scope

**The eslint rule.** `no-restricted-imports` forbidding `@genroot/builder/ui/*` and `@genroot/builder/modules/*` under `src/generators/*V2/`. This is the slice that makes the whole effort durable: without it, the next migration reintroduces the leaks by copying an existing V2 generator as a template — which is exactly how they arrived in the first place. 21 generators remain to migrate.

**Sabotage-verified in three directions** (rather than just asserting it lints clean):

| Sabotage | Result |
| --- | --- |
| Value import from `builder/ui` into a V2 generator | caught |
| **Type-only** import from `builder/modules` into a V2 generator | caught |
| Same import into a **v1** generator | correctly silent — v1 is allowed |

The type-only case matters most: nearly every leak this effort removed was a type import, and a rule that missed them would have been quietly useless.

**The last alias renames.** Four generators still used the deprecated `*Input` names; they move to `*Control`, and the aliases are deleted.

**A stronger test.** The alias test pinned something that no longer exists, so it's replaced by one pinning `GeneratorUI`'s entire member list. `GeneratorUI` is one of only two runtime surfaces a V2 author imports, so its members are a public contract rather than an implementation detail — adding or removing a control should be a deliberate edit, and this catches the aliases sneaking back.

**AGENTS.md** gains a "V2 generator surface" section, where the next agent to migrate a generator will actually look.

## Verification

- **353/353 Playwright** — full suite; this slice touches four generators plus the shared `GeneratorUI`.
- **15/15** v2 unit tests.
- CI's quality sequence run as one command (`types:check && lint && test:unit`), exit 0.

## Result

All 13 V2 generators import from `@genroot/builder/v2` and nothing else inside `src/builder`, and the rule keeps it that way. `builder/ui` and `builder/modules` now have no V2 consumers — the precondition for retiring them once v1 is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)