### PR TITLE
Fix Glint V2 CI coverage

### DIFF
--- a/src/builder/generatorUI.test.tsx
+++ b/src/builder/generatorUI.test.tsx
@@ -150,6 +150,7 @@ describe("GeneratorUI surface", () => {
       "History",
       "Instructions",
       "LoadedTextureControl",
+      "LoadedTextureControlV2",
       "MediaHero",
       "RangeControl",
       "SelectControl",

--- a/tests/generators/minecraftArmorGenerator/minecraftArmorGenerator.spec.ts
+++ b/tests/generators/minecraftArmorGenerator/minecraftArmorGenerator.spec.ts
@@ -11,10 +11,11 @@ const outputPage = (page: Page): Locator =>
 const combo = (page: Page, index: number): Locator =>
   page.getByRole("combobox").nth(index);
 
-// Visually-hidden checkboxes are toggled via a scripted click, as a normal
-// Playwright click fails the visibility wait.
+// Click the visible label rather than the visually-hidden checkbox. This waits
+// for a real browser interaction, including React hydration, before changing
+// the controlled value.
 const toggleCheckbox = (page: Page, name: string) =>
-  page.getByLabel(name).evaluate((el) => (el as HTMLInputElement).click());
+  page.getByText(name, { exact: true }).click();
 
 const optionListsOf = (page: Page): Promise<string[][]> =>
   page


### PR DESCRIPTION
## Scope
- Add LoadedTextureControlV2 to the pinned GeneratorUI public-surface test.
- Replace Armor's raw hidden-checkbox DOM click with a visible-label interaction that waits for React hydration.

## Verification
- npm run test:unit — 38 files, 145 tests passed
- npm run types:check
- npm run lint
- Full Playwright suite — 330 tests passed on isolated port 3003