### PR TITLE
Add includeNoTint support to the tint selector V2

### DIFF
--- a/src/generators/_common/tintSelectorV2/tintSelector.tsx
+++ b/src/generators/_common/tintSelectorV2/tintSelector.tsx
@@ -42,17 +42,19 @@ export function TintSelector({
   onChange,
   label,
   swatchGroups,
+  includeNoTint = true,
 }: {
   value: string | null;
   onChange: (hex: string | null) => void;
   label: string;
   swatchGroups: TintSwatchGroup[];
+  includeNoTint?: boolean;
 }) {
   const labelId = React.useId();
 
   const tintSwatches = flattenTintSwatchGroups(swatchGroups);
   const categoryChoices = [
-    noneChoice,
+    ...(includeNoTint ? [noneChoice] : []),
     ...swatchGroups.map(makeGroupOption),
     customChoice,
   ];

--- a/src/generators/testApiTintSelector/testApiTintSelectorGenerator.tsx
+++ b/src/generators/testApiTintSelector/testApiTintSelectorGenerator.tsx
@@ -27,6 +27,9 @@ its only other current exercise is temporary throwaway wiring in the Banner
 & Shield skeleton generator. Mounts the control on its own with a single dye
 swatch group and draws whatever color it resolves to, so a pixel read
 confirms the selection reached the render pass.
+
+A second control below it sets \`includeNoTint={false}\`, for generators
+(Armor, Horse, Cat) whose tint must always have a value.
 `;
 
 const images: ImageDef[] = [];
@@ -35,6 +38,7 @@ const textures: TextureDef[] = [];
 
 type TintSelectorProps = {
   tint: string | null;
+  requiredTint: string;
 };
 
 const render = (ctx: RenderContext, props: TintSelectorProps): void => {
@@ -43,6 +47,7 @@ const render = (ctx: RenderContext, props: TintSelectorProps): void => {
   if (props.tint) {
     ctx.fillRectangle([20, 20, 64, 64], props.tint);
   }
+  ctx.fillRectangle([100, 20, 64, 64], props.requiredTint);
 };
 
 const testApiTintSelectorGenerator: Generator<TintSelectorProps> = {
@@ -53,10 +58,14 @@ const testApiTintSelectorGenerator: Generator<TintSelectorProps> = {
   render,
 };
 
+const defaultRequiredTint = getFirstSwatchColor(dyeTintGroup) ?? "#1D1D21";
+
 function Component(): JSX.Element {
   const [tint, setTint] = React.useState<string | null>(
     getFirstSwatchColor(dyeTintGroup)
   );
+  const [requiredTint, setRequiredTint] =
+    React.useState<string>(defaultRequiredTint);
 
   return (
     <div className="lg:flex gap-8">
@@ -73,13 +82,21 @@ function Component(): JSX.Element {
             swatchGroups={[dyeTintGroup]}
             onChange={setTint}
           />
+
+          <TintSelector
+            value={requiredTint}
+            label="Required Tint"
+            swatchGroups={[dyeTintGroup]}
+            includeNoTint={false}
+            onChange={(hex) => setRequiredTint(hex ?? defaultRequiredTint)}
+          />
         </div>
       </div>
 
       <div className="flex-1 min-w-0">
         <GeneratorRenderer
           generator={testApiTintSelectorGenerator}
-          props={{ tint }}
+          props={{ tint, requiredTint }}
         />
       </div>
     </div>

--- a/tests/generators/testApiTintSelectorGenerator/testApiTintSelectorGenerator.spec.ts
+++ b/tests/generators/testApiTintSelectorGenerator/testApiTintSelectorGenerator.spec.ts
@@ -15,6 +15,15 @@ const custom: Rgba = { r: 0x33, g: 0x55, b: 0xff, a: 255 };
 const renderedTint = (page: Page) =>
   readPixel(page.getByTestId("generator-page-image").nth(0), 50, 50);
 
+const renderedRequiredTint = (page: Page) =>
+  readPixel(page.getByTestId("generator-page-image").nth(0), 130, 50);
+
+// Each `TintSelector` instance's label text sits in its own outer wrapper
+// div alongside its select/swatch-grid, so scoping to that wrapper is how a
+// specific instance's controls are found on a page with more than one.
+const tintSelector = (page: Page, label: string) =>
+  page.getByText(label, { exact: true }).locator("..");
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/generator/test-api-tint-selector");
 });
@@ -24,19 +33,43 @@ test("defaults to the first dye swatch", async ({ page }) => {
 });
 
 test("clicking a swatch updates the render", async ({ page }) => {
-  await page.getByRole("button", { name: "Red (#B02E26)" }).click();
+  await tintSelector(page, "Tint")
+    .getByRole("button", { name: "Red (#B02E26)" })
+    .click();
   await expect.poll(() => renderedTint(page)).toEqual(red);
 });
 
 test("switching to Custom Tint and typing a hex updates the render", async ({
   page,
 }) => {
-  await page.getByRole("combobox").selectOption({ label: "Custom Tint" });
-  await page.getByPlaceholder("RRGGBB").fill("3355FF");
+  await tintSelector(page, "Tint")
+    .getByRole("combobox")
+    .selectOption({ label: "Custom Tint" });
+  await tintSelector(page, "Tint").getByPlaceholder("RRGGBB").fill("3355FF");
   await expect.poll(() => renderedTint(page)).toEqual(custom);
 });
 
 test("switching to None clears the render", async ({ page }) => {
-  await page.getByRole("combobox").selectOption({ label: "None" });
+  await tintSelector(page, "Tint")
+    .getByRole("combobox")
+    .selectOption({ label: "None" });
   await expect.poll(() => renderedTint(page)).toEqual(white);
+});
+
+test("Required Tint has no None option", async ({ page }) => {
+  const options = await tintSelector(page, "Required Tint")
+    .locator("option")
+    .allTextContents();
+  expect(options).not.toContain("None");
+});
+
+test("Required Tint defaults to the first dye swatch and stays selectable via swatches", async ({
+  page,
+}) => {
+  await expect.poll(() => renderedRequiredTint(page)).toEqual(black);
+
+  await tintSelector(page, "Required Tint")
+    .getByRole("button", { name: "Red (#B02E26)" })
+    .click();
+  await expect.poll(() => renderedRequiredTint(page)).toEqual(red);
 });


### PR DESCRIPTION
## Summary

- Ports V1 tint selector's `includeNoTint` prop onto the V2 tint selector (`_common/tintSelectorV2/tintSelector.tsx`): when `false`, the "None" entry is omitted from the category dropdown entirely.
- This is the one real blocker found when comparing V1 and V2 feature parity — three live generators (`minecraftArmor`, `minecraftHorse`, `minecraftCat`) each pass `includeNoTint={false}` today because their tint must always have a value (per-part armor color, horse armor color, cat collar color), and V2 had no equivalent.
- Extends the `test-api-tint-selector` coverage board with a second, `includeNoTint={false}` control ("Required Tint"), and adds Playwright coverage confirming "None" is absent from its dropdown while swatch selection still works normally.

Migrating Armor/Horse/Cat off the V1 tint selector onto V2 is separate follow-up work — each has its own Playwright coverage tied to V1's single-dropdown DOM shape, which needs review since V2's dropdown+swatch-grid layout is structurally different.

## Test plan

- [x] `npm run types:check` / `npm run lint` / `npm run check:imports` clean
- [x] Full unit suite (42 files / 227 tests)
- [x] Full cold Playwright suite (362/362, run on an isolated port since another worktree held 3001)