### PR TITLE
Add optional page size to usePage, enabling non-A4 pages

### DIFF
--- a/src/builder/engine/engine.ts
+++ b/src/builder/engine/engine.ts
@@ -18,7 +18,7 @@ import {
 } from "./renderers/drawTab";
 import { drawText } from "./renderers/drawText";
 import { fillBackgroundColor } from "./renderers/fillBackgroundColor";
-import { type Page } from "./modelPage";
+import { type Page, type PageSize } from "./modelPage";
 import { fillRect } from "./renderers/fillRect";
 import { Color, getCanvasWithContextPixelColor } from "./canvasWithContext";
 
@@ -56,8 +56,8 @@ export class Engine {
     return this.model.getNumberVariable(id);
   }
 
-  usePage(id: string): void {
-    this.model.usePage(id);
+  usePage(id: string, size?: PageSize): void {
+    this.model.usePage(id, size);
   }
 
   fillBackgroundColorWithWhite() {

--- a/src/builder/engine/model.ts
+++ b/src/builder/engine/model.ts
@@ -1,6 +1,6 @@
 import { type ImageWithCanvas } from "./imageWithCanvas";
 import { type Texture } from "./texture";
-import { type Page, makePage } from "./modelPage";
+import { A4, type Page, type PageSize, makePage } from "./modelPage";
 import { type Values } from "./modelValues";
 import { type Region } from "./renderers/types";
 
@@ -105,14 +105,14 @@ export class Model {
     return newPage;
   }
 
-  usePage(id: string) {
+  usePage(id: string, size: PageSize = A4.px) {
     const page = this.findPage(id);
     if (page) {
       this.setCurrentPage(page);
       return;
     }
 
-    const newPage = makePage(id);
+    const newPage = makePage(id, size);
 
     this.addPage(newPage);
     this.setCurrentPage(newPage);

--- a/src/builder/engine/modelPage.test.ts
+++ b/src/builder/engine/modelPage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { A4, pxToMm, swapPageSize } from "./modelPage";
+
+describe("pxToMm", () => {
+  it("converts A4's own px width/height to its known mm size", () => {
+    expect(pxToMm(A4.px.width)).toBeCloseTo(A4.mm.width, 0);
+    expect(pxToMm(A4.px.height)).toBeCloseTo(A4.mm.height, 0);
+  });
+
+  it("scales linearly", () => {
+    expect(pxToMm(72)).toBeCloseTo(25.4, 5);
+    expect(pxToMm(0)).toBe(0);
+  });
+});
+
+describe("swapPageSize", () => {
+  it("swaps width and height", () => {
+    expect(swapPageSize({ width: 595, height: 842 })).toEqual({
+      width: 842,
+      height: 595,
+    });
+  });
+
+  it("round-trips back to the original", () => {
+    const size = { width: 100, height: 50 };
+    expect(swapPageSize(swapPageSize(size))).toEqual(size);
+  });
+});

--- a/src/builder/engine/modelPage.ts
+++ b/src/builder/engine/modelPage.ts
@@ -23,7 +23,18 @@ export type Page = {
   canvasWithContext: CanvasWithContext;
 };
 
-export function makePage(id: string): Page {
-  const canvasWithContext = makeCanvasWithContext(A4.px.width, A4.px.height);
+export function makePage(id: string, size: PageSize = A4.px): Page {
+  const canvasWithContext = makeCanvasWithContext(size.width, size.height);
   return { id, canvasWithContext };
+}
+
+export function swapPageSize({ width, height }: PageSize): PageSize {
+  return { width: height, height: width };
+}
+
+// A4.px (595x842) is already the standard 72dpi-rounded PDF point size for
+// A4.mm (210x297mm), not a 96dpi CSS-pixel size — so mm conversion divides by
+// 72, not 96.
+export function pxToMm(px: number): number {
+  return (px / 72) * 25.4;
 }

--- a/src/builder/generator.ts
+++ b/src/builder/generator.ts
@@ -18,6 +18,7 @@ import {
   type TabOrientation,
 } from "@genroot/builder/engine/renderers/drawTab";
 import { type Texture } from "@genroot/builder/engine/texture";
+import { type PageSize } from "@genroot/builder/engine/modelPage";
 
 // The render surface an author's `render` function draws through: drawing
 // and page methods (matching `Engine`'s own signatures verbatim, none of
@@ -28,7 +29,7 @@ import { type Texture } from "@genroot/builder/engine/texture";
 // `onRegionClick` rather than a closure attached at define-time. Deliberately
 // not `Pick<Generator, …>` — see the generator-v2 prototype plan.
 export type RenderContext = {
-  usePage(id: string): void;
+  usePage(id: string, size?: PageSize): void;
   fillBackgroundColorWithWhite(): void;
   fillRectangle(rectangle: Rectangle, color: string): void;
   drawRectangle(rectangle: Rectangle, options?: DrawRectangeOptions): void;

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -81,7 +81,12 @@ export type {
 } from "@genroot/builder/engine/renderers/drawTexture";
 
 // Page sizes.
-export { A4 } from "@genroot/builder/engine/modelPage";
+export {
+  A4,
+  type PageSize,
+  swapPageSize,
+  pxToMm,
+} from "@genroot/builder/engine/modelPage";
 
 // Texture-picker state. Generic picker plumbing: the selection model plus its
 // serialization, which Block and Item drive through their own pickers.

--- a/src/builder/renderContextAdapter.ts
+++ b/src/builder/renderContextAdapter.ts
@@ -15,6 +15,7 @@ import {
   type TabOrientation,
 } from "@genroot/builder/engine/renderers/drawTab";
 import { type Texture } from "@genroot/builder/engine/texture";
+import { type PageSize } from "@genroot/builder/engine/modelPage";
 import { type RegionClickHandler, type RenderContext } from "./generator";
 
 // Delegates every draw/page method to an internal `Engine`, and
@@ -37,8 +38,8 @@ export class RenderContextAdapter implements RenderContext {
     this.onRegionClick = onRegionClick;
   }
 
-  usePage(id: string): void {
-    this.gen.usePage(id);
+  usePage(id: string, size?: PageSize): void {
+    this.gen.usePage(id, size);
   }
 
   fillBackgroundColorWithWhite(): void {

--- a/src/builder/ui/pages/pages.tsx
+++ b/src/builder/ui/pages/pages.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { type GeneratorDef } from "@genroot/builder/engine/generatorDef";
 import { type Model } from "@genroot/builder/engine/model";
-import { A4 } from "@genroot/builder/engine/modelPage";
 
 import { RegionControls } from "./regionControls";
 import { SaveAsPDFButton } from "./saveAsPDFButton";
@@ -29,6 +28,7 @@ export function Pages({
   return (
     <div>
       {model.pages.map((page, pageIndex) => {
+        const { width: pageWidth, height: pageHeight } = page.canvasWithContext;
         const dataUrl = page.canvasWithContext.canvas.toDataURL("image/png");
 
         const fileName =
@@ -44,10 +44,13 @@ export function Pages({
 
             <div
               className="mb-6 flex items-center justify-between gap-3"
-              style={{ maxWidth: px(A4.px.width) }}
+              style={{ maxWidth: px(pageWidth) }}
             >
               <div className="flex items-center gap-3">
-                <PrintImageButton dataUrl={dataUrl} />
+                <PrintImageButton
+                  dataUrl={dataUrl}
+                  size={{ width: pageWidth, height: pageHeight }}
+                />
                 {pageIndex === 0 ? (
                   <SaveAsPDFButton generatorDef={generatorDef} model={model} />
                 ) : null}
@@ -60,7 +63,7 @@ export function Pages({
             {/* Important: The following div uses absolute positioning for the regions. */}
             <div
               className="relative"
-              style={{ maxWidth: px(A4.px.width + pageBorderWidth * 2) }}
+              style={{ maxWidth: px(pageWidth + pageBorderWidth * 2) }}
             >
               <img
                 ref={containerElRef}
@@ -73,6 +76,7 @@ export function Pages({
               {containerWidth ? (
                 <RegionControls
                   containerWidth={containerWidth}
+                  nativeWidth={pageWidth}
                   model={model}
                   currentPageId={page.id}
                   onClick={(callback) => {

--- a/src/builder/ui/pages/printImageButton.test.ts
+++ b/src/builder/ui/pages/printImageButton.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { A4, swapPageSize } from "@genroot/builder/engine/modelPage";
+import { getPrintPageSizeMm, getPrintStyles } from "./printImageButton";
+
+describe("getPrintPageSizeMm", () => {
+  it("converts a portrait page's own px size to mm", () => {
+    const size = getPrintPageSizeMm(A4.px);
+    expect(size.width).toBeCloseTo(A4.mm.width, 0);
+    expect(size.height).toBeCloseTo(A4.mm.height, 0);
+  });
+
+  it("converts a landscape page's own px size to mm", () => {
+    const size = getPrintPageSizeMm(swapPageSize(A4.px));
+    expect(size.width).toBeCloseTo(A4.mm.height, 0);
+    expect(size.height).toBeCloseTo(A4.mm.width, 0);
+  });
+});
+
+function extractPageSizeMm(styles: string): [number, number] {
+  const match = styles.match(/@page\s*\{\s*size:\s*([\d.]+)mm\s+([\d.]+)mm;/);
+  if (!match || !match[1] || !match[2]) {
+    throw new Error("No @page size rule found in print styles");
+  }
+  return [Number(match[1]), Number(match[2])];
+}
+
+describe("getPrintStyles", () => {
+  it("declares an @page size matching a portrait page's own mm size", () => {
+    const [width, height] = extractPageSizeMm(getPrintStyles(A4.px));
+    expect(width).toBeCloseTo(A4.mm.width, 0);
+    expect(height).toBeCloseTo(A4.mm.height, 0);
+  });
+
+  it("declares an @page size matching a landscape page's own mm size — the missing rule that let a landscape page overflow onto a second printed sheet", () => {
+    const [width, height] = extractPageSizeMm(
+      getPrintStyles(swapPageSize(A4.px))
+    );
+    expect(width).toBeCloseTo(A4.mm.height, 0);
+    expect(height).toBeCloseTo(A4.mm.width, 0);
+  });
+});

--- a/src/builder/ui/pages/printImageButton.tsx
+++ b/src/builder/ui/pages/printImageButton.tsx
@@ -1,27 +1,47 @@
 import React from "react";
-import { A4 } from "@genroot/builder/engine/modelPage";
+import { type PageSize, pxToMm } from "@genroot/builder/engine/modelPage";
 import { Button } from "../button/button";
 import { printElement } from "../utils/printHtmlElement";
 
-export function PrintImageButton({ dataUrl }: { dataUrl: string }) {
+export function getPrintPageSizeMm(size: PageSize): PageSize {
+  return { width: pxToMm(size.width), height: pxToMm(size.height) };
+}
+
+// `@page { size }` tells the print engine the physical paper
+// size/orientation to use — without it, a landscape-shaped page still prints
+// onto a default portrait sheet, overflows the printable width, and the
+// browser tiles the overflow onto a second page.
+export function getPrintStyles(size: PageSize): string {
+  const { width, height } = getPrintPageSizeMm(size);
+  return `
+    @page {
+      size: ${width}mm ${height}mm;
+    }
+    @media print {
+      html, body, img {
+        margin: 0;
+        padding: 0;
+        width: ${width}mm;
+        height: ${height}mm;
+      }
+    }
+  `;
+}
+
+export function PrintImageButton({
+  dataUrl,
+  size,
+}: {
+  dataUrl: string;
+  size: PageSize;
+}) {
   const onClick = (event: React.SyntheticEvent) => {
     event.preventDefault();
 
     const imageEl = new Image();
 
     imageEl.onload = () => {
-      const styles = `
-        @media print {
-          html, body, img {
-            margin: 0;
-            padding: 0;
-            width: ${A4.mm.width}mm;
-            height: ${A4.mm.height}mm;
-          }
-        }
-      `;
-
-      printElement(imageEl, { styles });
+      printElement(imageEl, { styles: getPrintStyles(size) });
     };
 
     imageEl.src = dataUrl;

--- a/src/builder/ui/pages/regionControls.tsx
+++ b/src/builder/ui/pages/regionControls.tsx
@@ -1,6 +1,5 @@
 import type { CSSProperties } from "react";
 import { type Model } from "@genroot/builder/engine/model";
-import { A4 } from "@genroot/builder/engine/modelPage";
 import { type Region } from "@genroot/builder/engine/renderers/types";
 import { px, pageBorderWidth } from "./utils";
 
@@ -8,8 +7,12 @@ function scaleNumber(value: number, scale: number): number {
   return Math.round(value * scale);
 }
 
-function scaleRegion([x, y, w, h]: Region, actualWidth: number): Region {
-  const scale = actualWidth / A4.px.width;
+function scaleRegion(
+  [x, y, w, h]: Region,
+  actualWidth: number,
+  nativeWidth: number
+): Region {
+  const scale = actualWidth / nativeWidth;
   return [
     scaleNumber(x, scale),
     scaleNumber(y, scale),
@@ -22,11 +25,13 @@ export function RegionControls({
   model,
   currentPageId,
   containerWidth,
+  nativeWidth,
   onClick,
 }: {
   model: Model;
   currentPageId: string;
   containerWidth: number;
+  nativeWidth: number;
   onClick: (callback: () => void) => void;
 }) {
   const regionControls = model.regionControls.filter(
@@ -40,7 +45,11 @@ export function RegionControls({
   return (
     <div>
       {regionControls.map((regionControl, i) => {
-        const [x, y, w, h] = scaleRegion(regionControl.region, containerWidth);
+        const [x, y, w, h] = scaleRegion(
+          regionControl.region,
+          containerWidth,
+          nativeWidth
+        );
         const style: CSSProperties = {
           top: px(y + pageBorderWidth),
           left: px(x + pageBorderWidth),

--- a/src/builder/ui/pages/saveAsPDFButton.test.ts
+++ b/src/builder/ui/pages/saveAsPDFButton.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { A4, swapPageSize } from "@genroot/builder/engine/modelPage";
+import { getPdfPageSpec } from "./saveAsPDFButton";
+
+describe("getPdfPageSpec", () => {
+  it("derives a portrait spec from a portrait-shaped page", () => {
+    const spec = getPdfPageSpec(A4.px);
+    expect(spec.orientation).toBe("portrait");
+    expect(spec.format[0]).toBeCloseTo(A4.mm.width, 0);
+    expect(spec.format[1]).toBeCloseTo(A4.mm.height, 0);
+  });
+
+  it("derives a landscape spec from a landscape-shaped page", () => {
+    const spec = getPdfPageSpec(swapPageSize(A4.px));
+    expect(spec.orientation).toBe("landscape");
+    expect(spec.format[0]).toBeCloseTo(A4.mm.height, 0);
+    expect(spec.format[1]).toBeCloseTo(A4.mm.width, 0);
+  });
+});

--- a/src/builder/ui/pages/saveAsPDFButton.tsx
+++ b/src/builder/ui/pages/saveAsPDFButton.tsx
@@ -1,8 +1,30 @@
 import { jsPDF } from "jspdf";
 import { type Model } from "@genroot/builder/engine/model";
+import { type Page, pxToMm } from "@genroot/builder/engine/modelPage";
 import { type GeneratorDef } from "@genroot/builder/engine/generatorDef";
-import { A4 } from "@genroot/builder/engine/modelPage";
+import { type CanvasWithContext } from "@genroot/builder/engine/canvasWithContext";
 import { Button } from "../button/button";
+
+export type PdfPageSpec = {
+  format: [number, number];
+  orientation: "portrait" | "landscape";
+};
+
+// jsPDF (4.2.1, verified empirically) only swaps an explicit `format: [w, h]`
+// array when `orientation` contradicts its own shape. `orientation` here is
+// always derived from that same `width`/`height` comparison, so it never
+// contradicts and the array is used as given.
+export function getPdfPageSpec({
+  width,
+  height,
+}: Pick<CanvasWithContext, "width" | "height">): PdfPageSpec {
+  const mmWidth = pxToMm(width);
+  const mmHeight = pxToMm(height);
+  return {
+    format: [mmWidth, mmHeight],
+    orientation: mmWidth > mmHeight ? "landscape" : "portrait",
+  };
+}
 
 export function SaveAsPDFButton({
   model,
@@ -12,18 +34,30 @@ export function SaveAsPDFButton({
   generatorDef: GeneratorDef;
 }) {
   const onSavePDF = () => {
-    const doc = new jsPDF({
-      orientation: "portrait",
-      unit: "mm",
-      format: "a4",
-    });
-    model.pages.forEach((page, index) => {
+    const [firstPage, ...restPages] = model.pages;
+    if (!firstPage) {
+      return;
+    }
+
+    const addPageImage = (page: Page, spec: PdfPageSpec, doc: jsPDF) => {
       const dataUrl = page.canvasWithContext.canvas.toDataURL("image/png");
-      if (index > 0) {
-        doc.addPage("a4", "portrait");
-      }
-      doc.addImage(dataUrl, "PNG", 0, 0, A4.mm.width, A4.mm.height);
+      doc.addImage(dataUrl, "PNG", 0, 0, spec.format[0], spec.format[1]);
+    };
+
+    const firstSpec = getPdfPageSpec(firstPage.canvasWithContext);
+    const doc = new jsPDF({
+      orientation: firstSpec.orientation,
+      unit: "mm",
+      format: firstSpec.format,
     });
+    addPageImage(firstPage, firstSpec, doc);
+
+    restPages.forEach((page) => {
+      const spec = getPdfPageSpec(page.canvasWithContext);
+      doc.addPage(spec.format, spec.orientation);
+      addPageImage(page, spec, doc);
+    });
+
     doc.save(generatorDef.name);
   };
 

--- a/src/generators/generators.ts
+++ b/src/generators/generators.ts
@@ -44,6 +44,7 @@ import { generator as testApiCuboidTabsGenerator } from "@genroot/generators/tes
 import { generator as testApiCuboidFoldsGenerator } from "@genroot/generators/testApiCuboidFolds/testApiCuboidFoldsGenerator";
 import { generator as testApiDrawTabGenerator } from "@genroot/generators/testApiDrawTab/testApiDrawTabGenerator";
 import { generator as testApiTexturePickerV2Generator } from "@genroot/generators/testApiTexturePickerV2/testApiTexturePickerV2Generator";
+import { generator as testApiPageSizeGenerator } from "@genroot/generators/testApiPageSize/testApiPageSizeGenerator";
 
 const isProductionEnvironment: boolean = process.env.NODE_ENV === "production";
 
@@ -128,6 +129,7 @@ export const testApiCoverage: GeneratorDefV2[] = [
   testApiCuboidFoldsGenerator,
   testApiDrawTabGenerator,
   testApiTexturePickerV2Generator,
+  testApiPageSizeGenerator,
 ];
 
 export const test: GeneratorDefV2[] = isProductionEnvironment

--- a/src/generators/testApiPageSize/testApiPageSizeGenerator.tsx
+++ b/src/generators/testApiPageSize/testApiPageSizeGenerator.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React from "react";
+import {
+  A4,
+  GeneratorRenderer,
+  GeneratorUI,
+  swapPageSize,
+  type GeneratorDefV2,
+  type Generator,
+  type ImageDef,
+  type InstructionsDef,
+  type Rectangle,
+  type RegionClickHandler,
+  type RenderContext,
+  type TextureDef,
+} from "@genroot/builder";
+
+const id = "test-api-page-size";
+
+const name = "Test API: Page Size";
+
+const instructions: InstructionsDef = `
+Diagnostic board for \`usePage\`'s optional \`size\` parameter
+(\`builder/engine/modelPage.ts\`). Renders a "Portrait" page with no size
+argument (proving the default still resolves to A4) alongside a "Landscape"
+page created via \`swapPageSize(A4.px)\` (proving an explicit size is
+respected). The Landscape page also carries two independently-clickable
+regions placed past x=595 — the old fixed portrait width — so a stale
+click-region scale factor would place them off-canvas and any click aimed at
+their real position would miss.
+`;
+
+const images: ImageDef[] = [];
+const textures: TextureDef[] = [];
+
+const regionA: Rectangle = [700, 60, 100, 100];
+const regionB: Rectangle = [700, 220, 100, 100];
+
+const clickedColor = "#22c55e";
+const defaultColor = "#9ca3af";
+
+type PageSizeProps = {
+  clicked: Record<string, boolean>;
+};
+
+const render = (ctx: RenderContext, props: PageSizeProps): void => {
+  ctx.usePage("Portrait");
+  ctx.fillBackgroundColorWithWhite();
+  ctx.drawText(`Portrait ${A4.px.width}x${A4.px.height}`, [20, 30], 14);
+  ctx.fillRectangle([20, 50, 60, 60], "#3b82f6");
+
+  ctx.usePage("Landscape", swapPageSize(A4.px));
+  ctx.fillBackgroundColorWithWhite();
+  ctx.drawText(`Landscape ${A4.px.height}x${A4.px.width}`, [20, 30], 14);
+
+  ctx.fillRectangle(
+    regionA,
+    props.clicked["region-a"] ? clickedColor : defaultColor
+  );
+  ctx.defineRegion(regionA, "region-a");
+
+  ctx.fillRectangle(
+    regionB,
+    props.clicked["region-b"] ? clickedColor : defaultColor
+  );
+  ctx.defineRegion(regionB, "region-b");
+};
+
+const testApiPageSizeGenerator: Generator<PageSizeProps> = {
+  id,
+  name,
+  images,
+  textures,
+  render,
+};
+
+function Component(): JSX.Element {
+  const [clicked, setClicked] = React.useState<Record<string, boolean>>({});
+
+  const onRegionClick: RegionClickHandler = ({ regionId }) => {
+    setClicked((current) => ({ ...current, [regionId]: !current[regionId] }));
+  };
+
+  return (
+    <div className="lg:flex gap-8">
+      <div
+        className="flex-1 min-w-0 mb-8 lg:mb-0"
+        data-testid="generator-sidebar"
+      >
+        <div className="w-full bg-gray-100 p-8 space-y-4">
+          <GeneratorUI.Instructions markdown={instructions} />
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <GeneratorRenderer
+          generator={testApiPageSizeGenerator}
+          props={{ clicked }}
+          onRegionClick={onRegionClick}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const generator: GeneratorDefV2 = {
+  id,
+  name,
+  thumbnail: null,
+  Component,
+};

--- a/tests/generators/testApiPageSizeGenerator/testApiPageSizeGenerator.spec.ts
+++ b/tests/generators/testApiPageSizeGenerator/testApiPageSizeGenerator.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readPixel, type Rgba } from "../_shared/pixelColor";
+
+// Generator API coverage for `usePage`'s optional `size` parameter
+// (`builder/engine/modelPage.ts`), added to support Diorama's landscape
+// mode. Generator id: test-api-page-size.
+//
+// Renders two pages: "Portrait" (usePage with no size arg, proving the
+// default still resolves to A4) and "Landscape" (usePage with
+// swapPageSize(A4.px), proving an explicit size is honored). The Landscape
+// page's two clickable regions sit at canvas x=700 — past 595, the old fixed
+// portrait width. Before this change, `RegionControls`' click-region scale
+// factor always divided by the fixed portrait width regardless of the real
+// page, so on this landscape page it would compute scale = 842/595 ≈ 1.415
+// instead of the correct 1.0 (the 1600x1400 Playwright viewport is wide
+// enough that neither page is ever CSS-shrunk below its native size) —
+// placing the overlay divs off to the right of the rendered image entirely,
+// so a click at the real, correct position would hit nothing.
+
+const defaultColor: Rgba = { r: 156, g: 163, b: 175, a: 255 };
+const clickedColor: Rgba = { r: 34, g: 197, b: 94, a: 255 };
+
+const pageImage = (page: Page, index: number) =>
+  page.getByTestId("generator-page-image").nth(index);
+
+const regionACenter = { x: 750, y: 110 };
+const regionBCenter = { x: 750, y: 270 };
+
+async function clickLandscapeRegion(
+  page: Page,
+  center: { x: number; y: number }
+) {
+  const image = pageImage(page, 1);
+  // The Landscape page block renders below the Portrait block and can sit
+  // partly outside the viewport — `boundingBox()` still reports its real
+  // page position, but `page.mouse.click` (unlike a locator's own `.click()`)
+  // doesn't auto-scroll, so a click below the fold silently hits nothing.
+  await image.scrollIntoViewIfNeeded();
+  const box = await image.boundingBox();
+  if (!box) {
+    throw new Error("Landscape page image has no bounding box");
+  }
+  // Native size is 842x595 (asserted separately) — scale the canvas-space
+  // target through the image's real rendered box so this test still holds if
+  // the viewport ever shrinks the image.
+  const nativeWidth = 842;
+  const nativeHeight = 595;
+  await page.mouse.click(
+    box.x + (center.x / nativeWidth) * box.width,
+    box.y + (center.y / nativeHeight) * box.height
+  );
+}
+
+test("Portrait keeps the default A4 size, Landscape uses its own swapped size", async ({
+  page,
+}) => {
+  await page.goto("/generator/test-api-page-size");
+
+  const [portraitSize, landscapeSize] = await Promise.all([
+    pageImage(page, 0).evaluate((img: HTMLImageElement) => [
+      img.naturalWidth,
+      img.naturalHeight,
+    ]),
+    pageImage(page, 1).evaluate((img: HTMLImageElement) => [
+      img.naturalWidth,
+      img.naturalHeight,
+    ]),
+  ]);
+
+  expect(portraitSize).toEqual([595, 842]);
+  expect(landscapeSize).toEqual([842, 595]);
+});
+
+test("clicking a landscape region toggles only that region", async ({
+  page,
+}) => {
+  await page.goto("/generator/test-api-page-size");
+
+  const landscape = pageImage(page, 1);
+
+  expect(await readPixel(landscape, regionACenter.x, regionACenter.y)).toEqual(
+    defaultColor
+  );
+  expect(await readPixel(landscape, regionBCenter.x, regionBCenter.y)).toEqual(
+    defaultColor
+  );
+
+  await clickLandscapeRegion(page, regionACenter);
+
+  expect(await readPixel(landscape, regionACenter.x, regionACenter.y)).toEqual(
+    clickedColor
+  );
+  expect(await readPixel(landscape, regionBCenter.x, regionBCenter.y)).toEqual(
+    defaultColor
+  );
+
+  await clickLandscapeRegion(page, regionBCenter);
+
+  expect(await readPixel(landscape, regionACenter.x, regionACenter.y)).toEqual(
+    clickedColor
+  );
+  expect(await readPixel(landscape, regionBCenter.x, regionBCenter.y)).toEqual(
+    clickedColor
+  );
+});


### PR DESCRIPTION
## Summary

Scoped as the standalone "Builder PR" step of the [Diorama Landscape Mode plan](https://github.com/pixelpapercraft/pixel-papercraft-generators) — required groundwork for a future Diorama landscape-mode follow-up PR, but has no dependency on Diorama itself and doesn't touch it.

- Threads an optional `size: PageSize` parameter through the full `usePage()` call chain (`RenderContext` → `RenderContextAdapter` → `Engine` → `Model` → `makePage`), defaulting to today's A4 portrait so all ~30 other generators are unaffected.
- Fixes four `builder/ui` files that hardcoded the single fixed A4-portrait page size instead of reading each page's own real pixel dimensions:
  - `regionControls.tsx` — click-region scale factor was computed against the fixed A4 width. This was a real correctness bug waiting to happen: any non-A4 page would have every clickable control positioned at the wrong scale.
  - `saveAsPDFButton.tsx` — now derives each page's own PDF orientation and mm size from its real pixel dimensions instead of one fixed A4 size for the whole document.
  - `printImageButton.tsx` — the injected print stylesheet now sizes the `@page` rule per page; previously there was no such rule at all, so a landscape page would overflow default portrait paper and print onto two sheets.
  - `pages.tsx` — on-screen container `maxWidth` now caps to each page's own real width instead of the fixed A4 width.
- Adds `swapPageSize`/`pxToMm` helpers (`modelPage.ts`) and a new dev-only `test-api-page-size` coverage board exercising a portrait and a landscape page side by side.

## Verification

- `npm run types:check` — clean
- `npm run lint` — clean
- `npm run check:imports` — clean
- Unit tests — 260/260
- Full cold Playwright suite (run against an isolated port, since 3001 was occupied by another local worktree) — 368/368

🤖 Generated with [Claude Code](https://claude.com/claude-code)